### PR TITLE
feat: futility pruning

### DIFF
--- a/search/src/negamax/utils.rs
+++ b/search/src/negamax/utils.rs
@@ -46,3 +46,11 @@ pub fn can_null_move_prune(board: &Board, remaining_depth: u8, in_check: bool) -
 pub fn can_razor_prune(remaining_depth: u8, in_check: bool) -> bool {
     remaining_depth <= RAZOR_MAX_DEPTH && remaining_depth > 0 && !in_check
 }
+
+pub const FUTILITY_MAX_DEPTH: u8 = 3;
+pub const FUTILITY_MARGINS: [i16; FUTILITY_MAX_DEPTH as usize + 1] = [0, 200, 300, 500];
+
+#[inline(always)]
+pub fn can_futility_prune(remaining_depth: u8, in_check: bool) -> bool {
+    remaining_depth <= FUTILITY_MAX_DEPTH && !in_check
+}


### PR DESCRIPTION
Tournament Summary
==================
Total Games: 184
Time control: 1s

1. Engine: ./target/release/grail
   Wins as White: 44
   Wins as Black: 27
   Draws: 61
   Score: 101.5/184
   Win Rate: 38.6%

2. Engine: ./target/release/grail-legacy
   Wins as White: 28
   Wins as Black: 24
   Draws: 61
   Score: 82.5/184
   Win Rate: 28.3%


Tournament Summary
==================
Total Games: 184
Time control: 100ms

1. Engine: ./target/release/grail
   Wins as White: 41
   Wins as Black: 42
   Draws: 51
   Score: 108.5/184
   Win Rate: 45.1%

2. Engine: ./target/release/grail-legacy
   Wins as White: 27
   Wins as Black: 23
   Draws: 51
   Score: 75.5/184
   Win Rate: 27.2%





| FEN # | Time (ms) | Δ        | Nodes     | Δ        | NPS     | Δ        |
|-------|-----------|----------|-----------|----------|---------|----------|
|     1 |      1839 | **-21.88%** |   7985657 | **-28.69%** | 4341623 | **-8.71%** |
|     2 |      3049 | **-71.18%** |  12534321 | **-71.98%** | 4110643 | **-2.79%** |
|     3 |       751 | **-29.88%** |   3156544 | **-48.71%** | 4202200 | **-26.86%** |
|     4 |      4649 | **-59.57%** |  17594495 | **-63.59%** | 3784458 | **-9.94%** |
|     5 |       934 | **-54.84%** |   3351532 | **-60.12%** | 3585918 | **-11.73%** |
|     6 |       508 | **-61.04%** |   2210373 | **-66.97%** | 4343531 | **-15.31%** |
|     7 |      2528 | **-12.68%** |   9069170 | **-30.07%** | 3586853 | **-19.91%** |
|     8 |       420 | **-57.06%** |   2088897 | **-63.12%** | 4962600 | **-14.29%** |
|     9 |      5341 | **-37.69%** |  20258332 | **-44.69%** | 3792812 | **-11.23%** |
|    10 |       937 | **-12.59%** |   4319403 | **-20.20%** | 4605180 | **-8.78%** |
| **Avg** |      2095 | **-41.84%** |   8256872 | **-49.81%** | 4131581 | **-12.96%** |