### PR TITLE
fix: deduplicate pv from movelist

### DIFF
--- a/search/src/negamax/engine.rs
+++ b/search/src/negamax/engine.rs
@@ -208,12 +208,13 @@ impl NegamaxEngine {
         mut alpha: i16,
         beta: i16,
     ) -> (Option<ChessMove>, i16) {
+        let best_move = self.current_pv.first().cloned();
+
         let moves_with_scores = ordered_moves(
             &self.board,
             None,
             0,
-            &self.current_pv,
-            None,
+            best_move,
             None,
             &self.killer_moves,
             &self.history_heuristic,
@@ -382,7 +383,6 @@ impl NegamaxEngine {
             board,
             None,
             depth,
-            &self.current_pv,
             maybe_tt_move,
             self.countermoves.get(board, &self.move_stack),
             &self.killer_moves,
@@ -660,7 +660,6 @@ impl NegamaxEngine {
             board,
             mask,
             depth,
-            &self.current_pv,
             None,
             None,
             &self.killer_moves,

--- a/search/src/utils/move_order.rs
+++ b/search/src/utils/move_order.rs
@@ -8,8 +8,7 @@ pub fn ordered_moves(
     board: &Board,
     mask: Option<BitBoard>,
     depth: u8,
-    pv_move: &[ChessMove],
-    tt_move: Option<ChessMove>,
+    best_move: Option<ChessMove>,
     countermove: Option<ChessMove>,
     killer_moves: &[[Option<ChessMove>; 2]],
     history_heuristic: &HistoryHeuristic,
@@ -22,17 +21,20 @@ pub fn ordered_moves(
     let mut moves_with_priority: Vec<(ChessMove, i32)> = Vec::with_capacity(64); // Rough estimate; chess max ~218
 
     let killers = &killer_moves[depth as usize];
-    let pv = pv_move.get(depth as usize).cloned();
+
+    if let Some(_tt) = best_move {
+        if board.legal(_tt) {
+            moves_with_priority.push((_tt, MAX_PRIORITY + 1));
+        }
+    }
 
     for mov in legal {
+        if Some(mov) == best_move {
+            continue;
+        }
+
         let mut priority = move_priority(&mov, board, history_heuristic);
 
-        if Some(mov) == tt_move {
-            priority = priority.max(MAX_PRIORITY + 1);
-        }
-        if Some(mov) == pv {
-            priority = priority.max(MAX_PRIORITY + 2);
-        }
         if Some(mov) == countermove {
             priority = priority.max(CAPTURE_PRIORITY - 2);
         }


### PR DESCRIPTION
removing the pv injection from the move list and relying entirely on the transposition table saw massive improvements in self play strength:

Tournament Summary
==================
Total Games: 184

1. Engine: ./target/release/grail
   Wins as White: 61
   Wins as Black: 47
   Draws: 58
   Score: 137.0/184
   Win Rate: 58.7%

2. Engine: ./target/release/grail-legacy
   Wins as White: 10
   Wins as Black: 8
   Draws: 58
   Score: 47.0/184
   Win Rate: 9.8%


| FEN # | Time (ms) | Δ        | Nodes     | Δ        | NPS     | Δ        |
|-------|-----------|----------|-----------|----------|---------|----------|
|     1 |      1001 | **-34.36%** |   3287043 | **-35.30%** | 3282926 | **-1.41%** |
|     2 |      1129 | **-48.40%** |   3361935 | **-47.33%** | 2976568 | **+2.03%** |
|     3 |       368 | **-24.74%** |   1355965 | **-24.54%** | 3684243 | **+0.43%** |
|     4 |      2610 | **-0.23%** |   8089669 | **-1.11%** | 3098597 | **-0.89%** |
|     5 |       199 | **-84.38%** |    700362 | **-82.00%** | 3512118 | **+15.06%** |
|     6 |       207 | **-44.35%** |    806383 | **-42.14%** | 3879034 | **+3.79%** |
|     7 |       356 | **-89.23%** |   1196215 | **-87.34%** | 3351737 | **+17.27%** |
|     8 |       145 | **-48.76%** |    607037 | **-47.89%** | 4165735 | **+1.20%** |
|     9 |       586 | **-81.18%** |   1798789 | **-79.50%** | 3069229 | **+8.92%** |
|    10 |       100 | **-78.40%** |    431820 | **-77.42%** | 4312972 | **+4.45%** |
| **Avg** |       670 | **-53.40%** |   2163521 | **-52.46%** | 3533315 | **+5.08%** |