### PR TITLE
fix: do history malus for quiet moves correctly

### DIFF
--- a/search/src/negamax/search.rs
+++ b/search/src/negamax/search.rs
@@ -398,6 +398,9 @@ impl NegamaxEngine {
             phase,
         );
 
+        // Used for punishing potentially "bad" quiet moves that were searched before a potential beta cutoff
+        let mut quiets_searched: Vec<ChessMove> = Vec::new();
+
         let mut move_index = -1;
         while let Some(m) = movegen.next(board, &self.history_heuristic) {
             move_index += 1;
@@ -429,14 +432,22 @@ impl NegamaxEngine {
                 alpha = alpha.max(best_value);
                 if alpha >= beta {
                     if is_quiet {
-                        self.on_quiet_fail_high(board, m, remaining_depth, depth as usize);
+                        self.on_quiet_fail_high(
+                            board,
+                            m,
+                            remaining_depth,
+                            depth as usize,
+                            &quiets_searched,
+                        );
                         self.countermoves.store(board, &self.move_stack, m);
                     }
                     break; // beta cutoff
                 }
 
-                if value < beta && is_quiet {
-                    self.on_quiet_fail_low(board, m, remaining_depth);
+                if is_quiet {
+                    // If we have a quiet move later that causes a cutoff, then this
+                    // move should have been sorted after, so let's punish it!
+                    quiets_searched.push(m);
                 }
             }
         }
@@ -711,6 +722,7 @@ impl NegamaxEngine {
         mv: ChessMove,
         remaining_depth: u8,
         depth: usize,
+        quiets_searched: &[ChessMove],
     ) {
         // Add killer move
         let killers = &mut self.killer_moves[depth];
@@ -719,16 +731,15 @@ impl NegamaxEngine {
             killers[0] = Some(mv);
         }
 
-        // Update history
+        // Apply malus to all previously searched quiet moves that did not cause a cutoff
+        let malus = self.history_heuristic.get_malus(remaining_depth);
+        for &q in quiets_searched {
+            self.history_heuristic.update(board, q, malus);
+        }
+
+        // Conversely, boost the move that caused the cutoff
         let bonus = self.history_heuristic.get_bonus(remaining_depth);
         self.history_heuristic.update(board, mv, bonus);
-    }
-
-    // Runs when a quiet move fails low (does not improve the bound)
-    #[inline(always)]
-    fn on_quiet_fail_low(&mut self, board: &Board, mv: ChessMove, remaining_depth: u8) {
-        let malus = self.history_heuristic.get_malus(remaining_depth);
-        self.history_heuristic.update(board, mv, malus);
     }
 
     #[inline(always)]

--- a/search/src/utils/history_heuristic.rs
+++ b/search/src/utils/history_heuristic.rs
@@ -1,9 +1,9 @@
 use chess::{Board, ChessMove, Color, Square, NUM_COLORS, NUM_SQUARES};
 
-const MAX_HISTORY: i32 = 16_384;
+const MAX_HISTORY: i32 = 512;
 const MAX_DEPTH: usize = 100;
-const HISTORY_REDUCE_THRESHOLD: i16 = 0; // reduce quiet late moves if history <= 0
-const HISTORY_LEAF_THRESHOLD: i16 = -1000; // prune quiet late moves if history very low
+const HISTORY_REDUCE_THRESHOLD: i16 = -8; // reduce quiet late moves if history <= -8
+const HISTORY_LEAF_THRESHOLD: i16 = -64; // prune quiet late moves if history very low
 const HISTORY_MOVE_GATE: i32 = 5; // only consider after some moves have been tried
 
 #[derive(Clone)]
@@ -36,8 +36,8 @@ impl HistoryHeuristic {
         let h = *entry as i32;
         let b = bonus.clamp(-(MAX_HISTORY), MAX_HISTORY);
 
-        // Optimized Stockfish formula: h += bonus - (h * |bonus|) / 2¹⁴
-        let new = h + b - ((h * b.abs()) >> 14);
+        // History gravity formula
+        let new = h + b - ((h * b.abs()) / MAX_HISTORY);
 
         *entry = new.clamp(-(MAX_HISTORY), MAX_HISTORY) as i16;
     }
@@ -107,7 +107,7 @@ const BONUS: [i32; MAX_DEPTH + 1] = {
     let mut i = 0;
     while i <= MAX_DEPTH {
         let depth = i as i32;
-        table[i] = 32 * depth * depth + 16 * depth;
+        table[i] = 13 * depth;
         i += 1;
     }
     table
@@ -117,7 +117,7 @@ const MALUS: [i32; MAX_DEPTH + 1] = {
     let mut i = 0;
     while i <= MAX_DEPTH {
         let depth = i as i32;
-        table[i] = -(12 * depth * depth + 6 * depth);
+        table[i] = -(10 * depth);
         i += 1;
     }
     table

--- a/search/src/utils/move_order.rs
+++ b/search/src/utils/move_order.rs
@@ -4,6 +4,8 @@ use chess::{Board, ChessMove, MoveGen, Piece};
 
 use crate::utils::{see, HistoryHeuristic};
 
+const COUNTERMOVE_BONUS: i16 = 64;
+
 struct ScoredMove {
     mov: ChessMove,
     score: i16,
@@ -148,7 +150,7 @@ impl MainMoveGenerator {
                         );
 
                         let counter = if self.countermove == Some(mov) {
-                            1000
+                            COUNTERMOVE_BONUS
                         } else {
                             0
                         };


### PR DESCRIPTION
As it turns out, the way I added malus to quiet moves was wrong. My original implementation only decreased the history value if a quiet failed low. However, according to the [Chess Wiki](https://www.chessprogramming.org/History_Heuristic),  we are supposed to penalize all quiets that was searched before one that causes a cutoff.

This makes sense since we want good moves to be ordered first (failing high early), and thus we penalize the moves that were searched before the cutoff move on the premise that they will be ordered lower going forward.

When initially changing this it performed worse than the faulty implementation, presumably because the system was tuned to the previous solution.

I have not spent much time tuning the system to this new implementation, but enough so that it at least outperforms the existing implementation slightly.

TLDR; There might be more strength to be gained with tuning.

Anyways, future Jørgen, here is the result of a 1m+1s tournament between the two:

```
Tournament Summary
==================
Total Games: 184

1. Engine: ./target/release/grail
   Wins as White: 36
   Wins as Black: 19
   Draws: 82
   Score: 96.0/184
   Win Rate: 29.9%

2. Engine: ./target/release/grail-legacy
   Wins as White: 28
   Wins as Black: 19
   Draws: 82
   Score: 88.0/184
   Win Rate: 25.5%

```