### PR TITLE
feat: threats in hce

### DIFF
--- a/evaluation/src/hce/config.rs
+++ b/evaluation/src/hce/config.rs
@@ -43,4 +43,7 @@ pub struct HCEConfig {
     // King safety - Positional
     pub king_central_penalty: i16, // penalty for central king in middlegame
     pub king_activity_bonus: i16,  // endgame king activity multiplier
+
+    // Threats
+    pub threats_multiplier: i16,
 }

--- a/evaluation/src/hce/eval_threats.rs
+++ b/evaluation/src/hce/eval_threats.rs
@@ -1,0 +1,12 @@
+use super::HCEConfig;
+use crate::hce::context::EvalContext;
+use chess::Color;
+
+/// Evaluate space advantage based on space controlled
+/// Uses cached attack map from Position (shared with threat detection)
+#[inline(always)]
+pub(super) fn evaluate(ctx: &EvalContext, color: Color, config: &HCEConfig) -> i16 {
+    // Count number of threats to opponent pieces
+    let num_threats = ctx.position.threats_for(!color);
+    config.threats_multiplier * num_threats.popcnt() as i16
+}

--- a/evaluation/src/hce/mod.rs
+++ b/evaluation/src/hce/mod.rs
@@ -8,6 +8,7 @@ mod eval_pawns;
 mod eval_queens;
 mod eval_rooks;
 mod eval_space;
+mod eval_threats;
 mod pawn_cache;
 mod pst;
 
@@ -88,6 +89,9 @@ impl HCE for Evaluator {
 
         cp += eval_space::evaluate_support(&ctx, Color::White, &self.config);
         cp -= eval_space::evaluate_support(&ctx, Color::Black, &self.config);
+
+        cp += eval_threats::evaluate(&ctx, Color::White, &self.config);
+        cp -= eval_threats::evaluate(&ctx, Color::Black, &self.config);
 
         // Tempo bonus
         if board.side_to_move() == Color::White {

--- a/search/src/config.rs
+++ b/search/src/config.rs
@@ -179,6 +179,9 @@ define_config!(
     (hce_king_central_penalty: i16, "HCE King Central Penalty", UciOptionType::Spin { min: 0, max: 50 }, 20, cfg!(feature = "tuning")),
     (hce_king_activity_bonus: i16, "HCE King Activity Bonus", UciOptionType::Spin { min: 0, max: 50 }, 14, cfg!(feature = "tuning")),
 
+    // Threats
+    (hce_threats_multiplier: i16, "HCE Threats Multiplier", UciOptionType::Spin { min: 0, max: 50 }, 20, cfg!(feature = "tuning")),
+
 );
 
 impl EngineConfig {
@@ -236,6 +239,9 @@ impl EngineConfig {
             king_pressure_pawn: self.hce_king_pressure_pawn.value,
             king_central_penalty: self.hce_king_central_penalty.value,
             king_activity_bonus: self.hce_king_activity_bonus.value,
+
+            // Threats
+            threats_multiplier: self.hce_threats_multiplier.value,
         }
     }
 }


### PR DESCRIPTION
```
Score of grail vs grail-legacy: 161 - 149 - 190  [0.512] 500
...      grail playing White: 89 - 73 - 88  [0.532] 250
...      grail playing Black: 72 - 76 - 102  [0.492] 250
...      White vs Black: 165 - 145 - 190  [0.520] 500
Elo difference: 8.3 +/- 24.0, LOS: 75.2 %, DrawRatio: 38.0 %
```