### PR TITLE
feat: hce diminishing passed pawns

### DIFF
--- a/evaluation/src/hce/config.rs
+++ b/evaluation/src/hce/config.rs
@@ -10,7 +10,6 @@ pub struct HCEConfig {
     pub backward_pawn_half_open_penalty: i16, // Extra penalty if on half-open file
     pub passed_pawn_linear: i16,              // Linear component of passed pawn bonus
     pub passed_pawn_quadratic: i16,           // Quadratic component (rank-1)^2
-    pub pawn_storm_bonus: i16,                // Bonus per rank for pawns storming enemy king
 
     // Piece bonuses
     pub bishop_pair_bonus: i16,

--- a/evaluation/src/hce/mod.rs
+++ b/evaluation/src/hce/mod.rs
@@ -67,10 +67,6 @@ impl HCE for Evaluator {
             self.pawn_cache.set(&ctx, cache_entry);
         };
 
-        // Pawn storms - evaluated separately because it depends on king positions
-        cp += eval_pawns::evaluate_pawn_storm(&ctx, Color::White, &self.config);
-        cp -= eval_pawns::evaluate_pawn_storm(&ctx, Color::Black, &self.config);
-
         cp += eval_rooks::evaluate(&ctx, Color::White, &self.config);
         cp -= eval_rooks::evaluate(&ctx, Color::Black, &self.config);
 

--- a/search/src/config.rs
+++ b/search/src/config.rs
@@ -145,7 +145,6 @@ define_config!(
 
     (hce_passed_pawn_linear: i16, "HCE Passed Pawn Linear", UciOptionType::Spin { min: 0, max: 20 }, 6, cfg!(feature = "tuning")),
     (hce_passed_pawn_quadratic: i16, "HCE Passed Pawn Quadratic", UciOptionType::Spin { min: 0, max: 10 }, 5, cfg!(feature = "tuning")),
-    (hce_pawn_storm_bonus: i16, "HCE Pawn Storm Bonus", UciOptionType::Spin { min: 0, max: 10 }, 2, cfg!(feature = "tuning")),
 
     // Piece bonuses
     (hce_bishop_pair_bonus: i16, "HCE Bishop Pair Bonus", UciOptionType::Spin { min: 0, max: 150 }, 50, cfg!(feature = "tuning")),
@@ -213,7 +212,6 @@ impl EngineConfig {
             backward_pawn_half_open_penalty: self.hce_backward_pawn_half_open_penalty.value,
             passed_pawn_linear: self.hce_passed_pawn_linear.value,
             passed_pawn_quadratic: self.hce_passed_pawn_quadratic.value,
-            pawn_storm_bonus: self.hce_pawn_storm_bonus.value,
 
             // Piece bonuses
             bishop_pair_bonus: self.hce_bishop_pair_bonus.value,


### PR DESCRIPTION
Score of grail vs grail-legacy: 131 - 102 - 267  [0.529] 500
...      grail playing White: 68 - 44 - 138  [0.548] 250
...      grail playing Black: 63 - 58 - 129  [0.510] 250
...      White vs Black: 126 - 107 - 267  [0.519] 500
Elo difference: 20.2 +/- 20.8, LOS: 97.1 %, DrawRatio: 53.4 %
