### PR TITLE
feat: see pruning in main search

### DIFF
--- a/search/src/config.rs
+++ b/search/src/config.rs
@@ -123,7 +123,8 @@ define_config!(
 
     // SEE Pruning
     (see_prune_min_remaining_depth: u8, "SEE Prune Min Remaining Depth", UciOptionType::Spin { min: 0, max: 10 }, 1, cfg!(feature = "tuning")),
-    (see_prune_depth_margin: i16, "SEE Prune Depth Margin", UciOptionType::Spin { min: 10, max: 150 }, 50, cfg!(feature = "tuning")),
+    (see_prune_max_depth: u8, "SEE Prune Max Depth", UciOptionType::Spin { min: 1, max: 10 }, 6, cfg!(feature = "tuning")),
+    (see_prune_depth_margin: i16, "SEE Prune Depth Margin", UciOptionType::Spin { min: 10, max: 150 }, 75, cfg!(feature = "tuning")),
     (see_prune_min_attacker_value: i16, "SEE Prune Min Attacker Value", UciOptionType::Spin { min: 0, max: 500 }, 200, cfg!(feature = "tuning")),
 
 

--- a/search/src/engine/search.rs
+++ b/search/src/engine/search.rs
@@ -476,17 +476,27 @@ impl Engine {
         let is_promotion = m.get_promotion() == Some(Piece::Queen);
         let is_tactical = in_check || gives_check || is_capture || is_promotion;
         let is_pv_node = beta > alpha + 1;
+        let is_pv_move = move_index == 0;
 
         if self.try_futility_prune(remaining_depth, in_check, is_tactical, alpha, static_eval) {
             return None;
         }
 
-        if self.try_see_prune(board, m, moved_piece, remaining_depth, in_check, is_pv_node) {
+        if self.try_see_prune(
+            board,
+            m,
+            moved_piece,
+            remaining_depth,
+            in_check,
+            is_pv_node,
+            is_pv_move,
+            alpha,
+            static_eval,
+        ) {
             return None;
         }
 
         // Late move reduction
-        let is_pv_move = move_index == 0;
         let mut reduction = lmr(
             remaining_depth,
             is_tactical,


### PR DESCRIPTION
Fairly simple premise:

If a capture looks questionable (i.e., not definetely good-looking), test it with SEE to check if any potential capture sequence is not horrible.

SEE is quite expensive since it does move generation, so when SEE is applied is quite strict:
1. if the attacking piece is worth more than the opponent piece
2. the attacking piece is not a pawn

Parameters to be tuned, but for this PR:
- Min remaining depth = 1, do not do SEE pruning when dropping into Q search
- Prune depth margin = 50, capture must look worse when we are searching deep
- min attacker value = 200, so basically care about see if we might loose a pawn initially