### PR TITLE
refactor: cleanup TODOs and consolidate constants

### DIFF
--- a/evaluation/src/scores.rs
+++ b/evaluation/src/scores.rs
@@ -1,7 +1,4 @@
 // Score bounds and special values for alpha-beta search.
-// TODO: consider removing POS/NEG_INFINITY and using SCORE_INF directly
-const SCORE_INF: i16 = 30_000;
-pub const POS_INFINITY: i16 = SCORE_INF;
-pub const NEG_INFINITY: i16 = -SCORE_INF;
+pub const SCORE_INF: i16 = 30_000;
 /// Base value for checkmate. Actual mate scores are MATE_VALUE - ply to distinguish faster mates.
 pub const MATE_VALUE: i16 = SCORE_INF - 1000;

--- a/nnue/src/bin/generate/histogram.rs
+++ b/nnue/src/bin/generate/histogram.rs
@@ -1,5 +1,5 @@
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
-use nnue::network::{CP_MAX, CP_MIN};
+use nnue::network::CP_BOUND;
 use std::sync::{Arc, Mutex};
 
 const BIN_SIZE: f32 = 1000.0;
@@ -23,7 +23,7 @@ impl ScoreHistogram {
         // Create a progress bar for each bin
         let mut progress_bars = Vec::with_capacity(NUM_BINS);
         for i in 0..NUM_BINS {
-            let range_start = CP_MIN as f32 + (i as f32 * BIN_SIZE);
+            let range_start = -CP_BOUND as f32 + (i as f32 * BIN_SIZE);
             let range_end = range_start + BIN_SIZE;
 
             let pb = multi_progress.add(ProgressBar::new(100));
@@ -106,8 +106,8 @@ impl HistogramHandle {
 
 fn score_to_bin_index(score: i16) -> usize {
     let score_f32 = score as f32;
-    let clamped = score_f32.clamp(CP_MIN as f32, CP_MAX as f32);
-    let normalized = clamped - CP_MIN as f32;
+    let clamped = score_f32.clamp(-CP_BOUND as f32, CP_BOUND as f32);
+    let normalized = clamped - (-CP_BOUND as f32);
     let bin = (normalized / BIN_SIZE) as usize;
     bin.min(NUM_BINS - 1)
 }

--- a/nnue/src/bin/generate/samples.rs
+++ b/nnue/src/bin/generate/samples.rs
@@ -1,4 +1,4 @@
-use nnue::network::{CP_MAX, CP_MIN};
+use nnue::network::CP_BOUND;
 use std::io::{self, Write};
 
 #[derive(Clone, Debug)]
@@ -15,7 +15,7 @@ impl Samples {
         let mut game_ids = Vec::with_capacity(evals.len());
         for (fen, score, game_id) in evals.iter() {
             fens.push(fen.clone().into_boxed_str());
-            scores.push((*score).clamp(CP_MIN, CP_MAX));
+            scores.push((*score).clamp(-CP_BOUND, CP_BOUND));
             game_ids.push(*game_id);
         }
         Self {

--- a/nnue/src/bin/train/dataset/loader.rs
+++ b/nnue/src/bin/train/dataset/loader.rs
@@ -9,14 +9,10 @@ use std::thread;
 
 use cozy_chess::{Board, Color};
 use nnue::encoding::{encode_board, NUM_FEATURES};
+use nnue::network::FV_SCALE;
 use utils::board_metrics::BoardMetrics;
 
 use super::indexer::SampleRef;
-
-/// Score scaling factor. Maps centipawn scores to a more neural-network-friendly range.
-/// 400cp → 1.0, typical advantage scores stay in [-1, 1] range.
-/// TODO: Use the one from network.rs
-pub const FV_SCALE: f32 = 400.0;
 
 // Holds x items in the channel per worker
 const CHANNEL_BUFFER_MULTIPLIER: usize = 2;

--- a/nnue/src/network/inference.rs
+++ b/nnue/src/network/inference.rs
@@ -7,7 +7,7 @@ use super::accumulator::Accumulator;
 use super::linear::LinearLayer;
 use super::model::Network;
 use super::simd::{simd_add, simd_relu};
-use super::{CP_MAX, CP_MIN, EMBEDDING_SIZE, FV_SCALE, HIDDEN_SIZE};
+use super::{CP_BOUND, EMBEDDING_SIZE, FV_SCALE, HIDDEN_SIZE};
 
 /// Main NNUE inference engine with quantized weights for fast evaluation.
 /// Uses an incremental accumulator for the embedding layer.
@@ -66,6 +66,6 @@ impl NNUENetwork {
             .forward(&self.hidden2_buffer, &mut self.output_buffer);
 
         // Scale to CP range
-        (self.output_buffer[0] * FV_SCALE).clamp(CP_MIN as f32, CP_MAX as f32)
+        (self.output_buffer[0] * FV_SCALE).clamp(-CP_BOUND as f32, CP_BOUND as f32)
     }
 }

--- a/nnue/src/network/mod.rs
+++ b/nnue/src/network/mod.rs
@@ -14,10 +14,8 @@ pub const EMBEDDING_SIZE: usize = 1024;
 /// Size of the hidden layers after the embedding.
 pub const HIDDEN_SIZE: usize = 16;
 
-// Evaluation clipping bounds (centipawns)
-// TODO: Consider only using a single value, since they are the same.
-pub const CP_MAX: i16 = 5000;
-pub const CP_MIN: i16 = -5000;
+/// Evaluation clipping bound (centipawns). Output is clamped to [-CP_BOUND, CP_BOUND].
+pub const CP_BOUND: i16 = 5000;
 
 /// Scale factor for network I/O.
 /// Training targets are divided by this, inference output is multiplied back.

--- a/search/src/engine/quiescence.rs
+++ b/search/src/engine/quiescence.rs
@@ -1,7 +1,7 @@
 use std::sync::atomic::Ordering;
 
 use cozy_chess::{Board, Color, Move, Piece, Rank};
-use evaluation::scores::{MATE_VALUE, NEG_INFINITY};
+use evaluation::scores::{MATE_VALUE, SCORE_INF};
 use utils::flip_eval_perspective;
 use utils::{game_phase, has_check, make_move, Position};
 
@@ -106,7 +106,7 @@ impl Engine {
         }
 
         let mut best_line = Vec::new();
-        let mut best_eval = if in_check { NEG_INFINITY } else { stand_pat };
+        let mut best_eval = if in_check { -SCORE_INF } else { stand_pat };
 
         let mut moves = QMoveGenerator::new(
             in_check,
@@ -188,7 +188,7 @@ impl Engine {
         }
 
         // If in check and no legal moves improved the position, it's checkmate
-        if in_check && best_eval == NEG_INFINITY {
+        if in_check && best_eval == -SCORE_INF {
             return (-(MATE_VALUE - depth as i16), Vec::new());
         }
 

--- a/search/src/pruning/aspiration.rs
+++ b/search/src/pruning/aspiration.rs
@@ -1,4 +1,4 @@
-use evaluation::scores::{NEG_INFINITY, POS_INFINITY};
+use evaluation::scores::SCORE_INF;
 
 #[derive(PartialEq, Debug)]
 pub enum Pass {
@@ -23,8 +23,8 @@ pub struct AspirationWindow {
 impl AspirationWindow {
     pub fn new(start_half: i16, widen: i16, enabled_from: u8) -> Self {
         Self {
-            alpha: NEG_INFINITY,
-            beta: POS_INFINITY,
+            alpha: -SCORE_INF,
+            beta: SCORE_INF,
             start_half,
             widen,
             enabled_from,
@@ -34,12 +34,12 @@ impl AspirationWindow {
     /// Sets up window for new depth based on previous score.
     pub fn begin_depth(&mut self, depth: u8, prev_score: i16) {
         if depth < self.enabled_from {
-            self.alpha = NEG_INFINITY;
-            self.beta = POS_INFINITY;
+            self.alpha = -SCORE_INF;
+            self.beta = SCORE_INF;
             return;
         }
 
-        let half = (self.start_half + 10 * depth as i16).min(POS_INFINITY);
+        let half = (self.start_half + 10 * depth as i16).min(SCORE_INF);
         self.alpha = prev_score.saturating_sub(half);
         self.beta = prev_score.saturating_add(half);
     }
@@ -68,7 +68,7 @@ impl AspirationWindow {
 
     /// Fully opens the window after too many failures.
     pub fn fully_extend(&mut self) {
-        self.alpha = NEG_INFINITY;
-        self.beta = POS_INFINITY;
+        self.alpha = -SCORE_INF;
+        self.beta = SCORE_INF;
     }
 }

--- a/uci/src/commands.rs
+++ b/uci/src/commands.rs
@@ -39,7 +39,7 @@ pub enum UciOutput {
 /// Search information sent to the GUI during analysis.
 ///
 /// Example: `info depth 4 seldepth 7 nodes 3274 nps 922805 time 3 score cp 10 pv e2e4 d7d5 e4d5 d8d5`
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Info {
     pub depth: u8,
     pub sel_depth: u8,
@@ -51,7 +51,7 @@ pub struct Info {
 }
 
 /// Evaluation score in UCI format.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum Score {
     /// Score in centipawns.
     Centipawns(i16),

--- a/uci/src/lib.rs
+++ b/uci/src/lib.rs
@@ -8,5 +8,6 @@ pub mod commands;
 
 pub use commands::{UciInput, UciOutput};
 pub use connection::UciConnection;
+pub use encoder::Encoder;
 pub use options::{UciOption, UciOptionType};
 pub use utils::{move_to_uci, pv_to_uci};


### PR DESCRIPTION
Addresses quick-fix TODOs from the documentation PR.

Changes:
- Replace `POS_INFINITY`/`NEG_INFINITY` with `SCORE_INF`/`-SCORE_INF`
- Consolidate `CP_MAX`/`CP_MIN` to single `CP_BOUND` constant
- Import `FV_SCALE` from network.rs instead of duplicating in loader.rs
- Use UCI encoder in benchmark instead of manual print formatting
- Rename depth variables in search_move for clarity (`reduced_max_depth`, `searched_depth`)

Also adds `Clone` to `Info` and `Copy` to `Score` for encoder usage.