### PR TITLE
fix: use CARGO_PKG_VERSION for CLI version string

### DIFF
--- a/core/src/args.rs
+++ b/core/src/args.rs
@@ -5,7 +5,7 @@ use clap::Parser;
 #[derive(Parser, Debug)]
 #[command(name = "Grail")]
 #[command(author = "Jørgen Hanssen <jorgen@hanssen.io>")]
-#[command(version = "0.1.0")]
+#[command(version = env!("CARGO_PKG_VERSION"))]
 pub struct Args {
     /// Log UCI communication to a file for debugging.
     #[arg(short, long)]


### PR DESCRIPTION
## Summary
Fixes the `--version` CLI flag to display the correct version from `Cargo.toml` instead of a hardcoded "0.1.0".

## Changes
- Replace hardcoded version string with `env!("CARGO_PKG_VERSION")` in `core/src/args.rs`

## Before
```
grail --version
Grail 0.1.0
```

## After
```
grail --version
Grail 1.0.0
```