### PR TITLE
refactor: remove unused search_moves from UCI go command

### DIFF
--- a/uci/src/commands.rs
+++ b/uci/src/commands.rs
@@ -70,8 +70,6 @@ impl Default for Score {
 pub struct GoParams {
     /// Search until "stop" is received.
     pub infinite: bool,
-    /// Restrict search to these moves only. TODO: not yet implemented.
-    pub search_moves: Option<Vec<String>>,
     /// White's remaining time in milliseconds.
     pub wtime: Option<u64>,
     /// Black's remaining time in milliseconds.

--- a/uci/src/decoder.rs
+++ b/uci/src/decoder.rs
@@ -83,7 +83,6 @@ impl Decoder {
     fn decode_go(&self, input: &str) -> UciInput {
         UciInput::Go(GoParams {
             infinite: input.contains("infinite"),
-            search_moves: None, // We'll implement this later
             wtime: extract_numeric_param(input, "wtime"),
             btime: extract_numeric_param(input, "btime"),
             winc: extract_numeric_param(input, "winc"),


### PR DESCRIPTION
## Summary
Removes the unimplemented `search_moves` field from `GoParams` rather than shipping dead code.

## Changes
- Remove `search_moves: Option<Vec<String>>` from `GoParams` in `uci/src/commands.rs`
- Remove initialization in `uci/src/decoder.rs`

## Context
The `searchmoves` UCI parameter restricts the engine to only consider specific moves. This is rarely used by GUIs and adds complexity without clear benefit. Removed as part of 1.0.0 cleanup.

## Note
This is technically a deviation from the UCI spec, but the parameter is optional and seldom used. Can be reconsidered post-1.0 if needed.