### PR TITLE
fix: always send bestmove response per UCI spec

### DIFF
--- a/uci/src/lib.rs
+++ b/uci/src/lib.rs
@@ -12,3 +12,7 @@ pub use decoder::Decoder;
 pub use encoder::Encoder;
 pub use options::{UciOption, UciOptionType};
 pub use utils::{move_to_uci, pv_to_uci};
+
+/// Null move in UCI format, used when no legal move exists (e.g., checkmate).
+/// Per UCI spec, this should be sent as the bestmove when the position has no legal moves.
+pub const NULL_MOVE: &str = "0000";


### PR DESCRIPTION
## Summary
Fixes a UCI compliance bug where `bestmove` was not sent when the position had no legal moves (e.g., already in checkmate).

## Problem
The UCI specification states:
> "for every 'go' command a 'bestmove' command is needed!"

Previously, when `search()` returned `None`, no `bestmove` was sent, which could cause GUIs to hang waiting for a response.

## Solution
- Added `NULL_MOVE` constant (`"0000"`) to the `uci` crate
- Updated `worker.rs` to always send a `bestmove`, using `0000` when no legal move exists

## Testing
```
./target/release/grail
Grail 1.0.0 by Jørgen Hanssen
position fen rnb1kbnr/pppp1ppp/8/4p3/6Pq/5P2/PPPPP2P/RNBQKBNR w KQkq - 1 3
go depth 20
info depth 0 seldepth 0 multipv 1 score mate 0 nodes 0 nps 0 time 0 pv 
bestmove 0000
```