### PR TITLE
Cleanup: Remove non-standard greeting and Raw output

### DIFF
--- a/core/src/grail.rs
+++ b/core/src/grail.rs
@@ -55,8 +55,6 @@ impl Grail {
 
     /// Runs the UCI protocol loop until quit.
     pub fn run(mut self) -> Result<(), Box<dyn std::error::Error>> {
-        self.send_greeting();
-
         let decoder = Decoder::new();
         let stdin = std::io::stdin();
 
@@ -124,13 +122,6 @@ impl Grail {
             UciInput::Unknown(line) => debug!("Unknown command: {}", line),
         }
         true
-    }
-
-    fn send_greeting(&self) {
-        let _ = self.output.send(UciOutput::Raw(format!(
-            "{} {} by {}",
-            ENGINE_NAME, ENGINE_VERSION, ENGINE_AUTHOR
-        )));
     }
 
     fn shutdown(self) {

--- a/uci/src/commands.rs
+++ b/uci/src/commands.rs
@@ -33,7 +33,6 @@ pub enum UciOutput {
     BestMove(String),
     Info(Info),
     Option(String),
-    Raw(String),
 }
 
 /// Search information sent to the GUI during analysis.

--- a/uci/src/encoder.rs
+++ b/uci/src/encoder.rs
@@ -28,7 +28,6 @@ impl Encoder {
                 )
             }
             UciOutput::Option(option_str) => option_str.clone(),
-            UciOutput::Raw(message) => message.clone(),
         }
     }
 }


### PR DESCRIPTION
## Summary
Removes non-standard UCI output for cleaner protocol compliance.

## Changes
- Removed `UciOutput::Raw` variant from the UCI crate
- Removed startup greeting banner ("Grail 1.0.0 by ...")

## Why
The UCI spec states engines should "boot and wait for input from the GUI". 
Sending unsolicited output before the `uci` command is non-standard.

The engine already identifies itself properly via `id name` and `id author` 
responses to the `uci` command, making the greeting redundant.

## Result
Engine now starts silently and responds only to UCI commands.