### PR TITLE
feat: recognize debug command

### DIFF
--- a/core/src/grail.rs
+++ b/core/src/grail.rs
@@ -89,6 +89,8 @@ impl Grail {
             UciInput::IsReady => {
                 let _ = self.output.send(UciOutput::ReadyOk);
             }
+            // TODO: Implement debug mode - send extra info via `info string` when enabled
+            UciInput::Debug(_enabled) => {}
             UciInput::SetOption { name, value } => {
                 if let Err(e) = self.config.update_from_uci(&name, &value) {
                     debug!("Option setting failed: {}", e);

--- a/uci/src/commands.rs
+++ b/uci/src/commands.rs
@@ -5,6 +5,7 @@ use cozy_chess::Board;
 #[derive(Debug)]
 pub enum UciInput {
     Uci,
+    Debug(bool),
     IsReady,
 
     UciNewGame,

--- a/uci/src/decoder.rs
+++ b/uci/src/decoder.rs
@@ -24,6 +24,7 @@ impl Decoder {
             "isready" => UciInput::IsReady,
             "ucinewgame" => UciInput::UciNewGame,
 
+            _ if input.starts_with("debug") => UciInput::Debug(input.ends_with(" on")),
             _ if input.starts_with("position") => self.decode_position(input),
             _ if input.starts_with("go") => self.decode_go(input),
             _ if input.starts_with("setoption") => self.decode_setoption(input),


### PR DESCRIPTION
## Summary
Properly recognize the UCI `debug` command instead of treating it as unknown.

## Changes
- Added `Debug(bool)` variant to `UciInput`
- Parse `debug on` / `debug off` in decoder
- Handler is a no-op (with TODO for future)

## Why
Previously `debug on/off` was silently ignored as an unknown command, 
which cluttered log files. Now it's properly recognized per UCI spec.