### PR TITLE
feat: add hashfull to search info output

### DIFF
--- a/search/src/engine/mod.rs
+++ b/search/src/engine/mod.rs
@@ -186,6 +186,7 @@ impl Engine {
                 sel_depth: self.max_depth_reached,
                 nodes: self.nodes,
                 nodes_per_second: nps,
+                hashfull: self.tt.hashfull(),
                 time: elapsed.as_millis() as u32,
                 score: if found_checkmate {
                     convert_mate_score(best_score)

--- a/search/src/transposition/main.rs
+++ b/search/src/transposition/main.rs
@@ -107,6 +107,25 @@ impl TranspositionTable {
         self.generation = self.generation.wrapping_add(1);
     }
 
+    /// Returns hash table fill rate in permille (0-1000).
+    ///
+    /// Samples the first 1000 entries to get an approximation of the fill rate.
+    /// Looping through the entire table would be too slow.
+    pub fn hashfull(&self) -> u16 {
+        const MAX_SAMPLE: usize = 1000;
+
+        let sample_size = self.entries.len().min(MAX_SAMPLE);
+        let sample = &self.entries[..sample_size];
+
+        // Count non-empty entries (key == 0)
+        let filled_count = sample.iter().filter(|e| e.key != 0).count();
+
+        // Convert to permille: (filled / sample_size) * 1000
+        let permille = (filled_count * 1000) / sample_size;
+
+        permille as u16
+    }
+
     // Prefetch TT entry into cache
     pub fn prefetch(&self, hash: u64) {
         let idx = (hash as usize) % self.buckets;

--- a/uci/src/commands.rs
+++ b/uci/src/commands.rs
@@ -45,6 +45,7 @@ pub struct Info {
     pub sel_depth: u8,
     pub nodes: u32,
     pub nodes_per_second: u32,
+    pub hashfull: u16,
     pub time: u32,
     pub pv: Vec<String>,
     pub score: Score,

--- a/uci/src/encoder.rs
+++ b/uci/src/encoder.rs
@@ -14,7 +14,7 @@ impl Encoder {
             UciOutput::BestMove(best_move) => format!("bestmove {}", best_move),
             UciOutput::Info(info) => {
                 format!(
-                    "info depth {} seldepth {} multipv 1 score {} nodes {} nps {} time {} pv {}",
+                    "info depth {} seldepth {} multipv 1 score {} nodes {} nps {} hashfull {} time {} pv {}",
                     info.depth,
                     info.sel_depth,
                     match info.score {
@@ -23,6 +23,7 @@ impl Encoder {
                     },
                     info.nodes,
                     info.nodes_per_second,
+                    info.hashfull,
                     info.time,
                     info.pv.join(" ")
                 )


### PR DESCRIPTION
Adds `hashfull` to the UCI info output, showing transposition table usage.