### PR TITLE
feat: add auto-tag workflow for releases

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   tag:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Adds a GitHub Actions workflow that automatically creates version tags when Cargo.toml is updated on main.

Tags trigger the existing build workflow, streamlining the release process