### PR TITLE
tune: update LMR and move ordering parameters from SPSA

### DIFF
--- a/search/src/config.rs
+++ b/search/src/config.rs
@@ -85,27 +85,27 @@ define_config!(
     (aspiration_window_depth: u8, "Aspiration Window Depth", UciOptionType::Spin { min: 1, max: 10 }, 5, cfg!(feature = "tuning")),
     (aspiration_window_retries: i16, "Aspiration Window Retries", UciOptionType::Spin { min: 1, max: 5 }, 3, cfg!(feature = "tuning")),
 
-    (history_max_value: i32, "History Max Value", UciOptionType::Spin { min: 128, max: 1024 }, 512, cfg!(feature = "tuning")),
-    (history_reduction_threshold: i16, "History Reduction Threshold", UciOptionType::Spin { min: -512, max: 512 }, -8, cfg!(feature = "tuning")),
-    (history_prune_threshold: i16, "History Prune Threshold", UciOptionType::Spin { min: -512, max: 512 }, -64, cfg!(feature = "tuning")),
+    (history_max_value: i32, "History Max Value", UciOptionType::Spin { min: 128, max: 1024 }, 482, cfg!(feature = "tuning")),
+    (history_reduction_threshold: i16, "History Reduction Threshold", UciOptionType::Spin { min: -512, max: 512 }, -12, cfg!(feature = "tuning")),
+    (history_prune_threshold: i16, "History Prune Threshold", UciOptionType::Spin { min: -512, max: 512 }, -66, cfg!(feature = "tuning")),
     (history_min_move_index: i32, "History Min Move Index", UciOptionType::Spin { min: 1, max: 10 }, 5, cfg!(feature = "tuning")),
     (history_bonus_multiplier: i32, "History Bonus Multiplier", UciOptionType::Spin { min: 0, max: 30 }, 13, cfg!(feature = "tuning")),
-    (history_malus_multiplier: i32, "History Malus Multiplier", UciOptionType::Spin { min: 0, max: 30 }, 4, cfg!(feature = "tuning")),
+    (history_malus_multiplier: i32, "History Malus Multiplier", UciOptionType::Spin { min: 0, max: 30 }, 7, cfg!(feature = "tuning")),
 
     (capture_history_max_value: i32, "Capture History Max Value", UciOptionType::Spin { min: 128, max: 1024 }, 512, cfg!(feature = "tuning")),
-    (capture_history_bonus_multiplier: i32, "Capture History Bonus Multiplier", UciOptionType::Spin { min: 0, max: 30 }, 9, cfg!(feature = "tuning")),
-    (capture_history_malus_multiplier: i32, "Capture History Malus Multiplier", UciOptionType::Spin { min: 0, max: 30 }, 2, cfg!(feature = "tuning")),
+    (capture_history_bonus_multiplier: i32, "Capture History Bonus Multiplier", UciOptionType::Spin { min: 0, max: 30 }, 10, cfg!(feature = "tuning")),
+    (capture_history_malus_multiplier: i32, "Capture History Malus Multiplier", UciOptionType::Spin { min: 0, max: 30 }, 3, cfg!(feature = "tuning")),
 
     (continuation_max_value: i32, "Continuation Max Value", UciOptionType::Spin { min: 128, max: 1024 }, 512, cfg!(feature = "tuning")),
     (continuation_max_moves: usize, "Continuation Max Moves", UciOptionType::Spin { min: 1, max: 4 }, 4, cfg!(feature = "tuning")),
-    (continuation_bonus_multiplier: i32, "Continuation Bonus Multiplier", UciOptionType::Spin { min: 0, max: 30 }, 9, cfg!(feature = "tuning")),
-    (continuation_malus_multiplier: i32, "Continuation Malus Multiplier", UciOptionType::Spin { min: 0, max: 30 }, 10, cfg!(feature = "tuning")),
+    (continuation_bonus_multiplier: i32, "Continuation Bonus Multiplier", UciOptionType::Spin { min: 0, max: 30 }, 8, cfg!(feature = "tuning")),
+    (continuation_malus_multiplier: i32, "Continuation Malus Multiplier", UciOptionType::Spin { min: 0, max: 30 }, 11, cfg!(feature = "tuning")),
 
-    (quiet_check_bonus: i16, "Quiet Check Bonus", UciOptionType::Spin { min: 0, max: 2000 }, 1000, cfg!(feature = "tuning")),
+    (quiet_check_bonus: i16, "Quiet Check Bonus", UciOptionType::Spin { min: 0, max: 2000 }, 980, cfg!(feature = "tuning")),
 
     (lmr_min_depth: u8, "LMR Min Depth", UciOptionType::Spin { min: 1, max: 10 }, 3, cfg!(feature = "tuning")),
     (lmr_divisor: i32, "LMR Divisor", UciOptionType::Spin { min: 100, max: 400 }, 230, cfg!(feature = "tuning")),
-    (lmr_max_reduction_ratio: i32, "LMR Max Reduction Ratio", UciOptionType::Spin { min: 10, max: 100 }, 50, cfg!(feature = "tuning")),
+    (lmr_max_reduction_ratio: i32, "LMR Max Reduction Ratio", UciOptionType::Spin { min: 10, max: 100 }, 52, cfg!(feature = "tuning")),
 
     (nmp_min_depth: u8, "NMP Min Depth", UciOptionType::Spin { min: 2, max: 10 }, 4, cfg!(feature = "tuning")),
     (nmp_base_reduction: u8, "NMP Base Reduction", UciOptionType::Spin { min: 1, max: 10 }, 2, cfg!(feature = "tuning")),


### PR DESCRIPTION
## Summary

SPSA tuning of LMR and move ordering parameters (history heuristics, continuation history, capture history).

<img width="1600" height="1200" alt="graph" src="https://github.com/user-attachments/assets/cec7135a-e1b7-432e-a99b-61d4be7d2099" />

## Changes

### History Heuristic
| Parameter | Before | After |
|-----------|--------|-------|
| History Max Value | 512 | 482 |
| History Reduction Threshold | -8 | -12 |
| History Prune Threshold | -64 | -66 |
| History Malus Multiplier | 4 | 7 |

### Capture History
| Parameter | Before | After |
|-----------|--------|-------|
| Capture History Bonus Multiplier | 9 | 10 |
| Capture History Malus Multiplier | 2 | 3 |

### Continuation History
| Parameter | Before | After |
|-----------|--------|-------|
| Continuation Bonus Multiplier | 9 | 8 |
| Continuation Malus Multiplier | 10 | 11 |

### LMR
| Parameter | Before | After |
|-----------|--------|-------|
| LMR Max Reduction Ratio | 50 | 52 |

### Move Ordering
| Parameter | Before | After |
|-----------|--------|-------|
| Quiet Check Bonus | 1000 | 980 |

## Results

```
Score of grail vs grail-next: 302 - 275 - 423  [0.513] 1000
...      grail playing White: 175 - 117 - 208  [0.558] 500
...      grail playing Black: 127 - 158 - 215  [0.469] 500
...      White vs Black: 333 - 244 - 423  [0.544] 1000
Elo difference: 9.4 +/- 16.3, LOS: 86.9 %, DrawRatio: 42.3 %
```