### PR TITLE
perf: use per-accumulator-neuron quantization scales

### DIFF
--- a/nnue/src/network/accumulator.rs
+++ b/nnue/src/network/accumulator.rs
@@ -16,28 +16,30 @@ use super::{EMBEDDING_SIZE, QUANTIZATION_PERCENTILE};
 /// the corresponding weight rows. This makes inference O(changed features)
 /// rather than O(all features).
 ///
-/// Weights are quantized to i8 and accumulated in i16 for speed (SIMD-friendly).
-/// Dequantization back to f32 happens only when outputting to the next layer.
+/// Weights are quantized to i8 and accumulated in i16 for wider SIMD.
+/// Dequantization back to f32 happens when outputting to the next layer.
 pub struct Accumulator {
     // [feature_idx][embedding_idx]
-    weights: Box<[i8]>,
+    weights: Vec<i8>,
     // [embedding_idx]
-    biases: Box<[i16]>,
+    biases: Vec<i16>,
     // Accumulated sum of active weights [embedding_idx]
     buffer: [i16; EMBEDDING_SIZE],
 
     // To know which inputs have changed since the last update
     previous_input: Bitset<NUM_FEATURES>,
 
-    // Scale factor to dequantize back to f32
-    scale: f32,
+    // Per-neuron weight quantization scale factors to convert it back to f32.
+    // USes 1/scale to avoid slower division operations.
+    inv_scales: Vec<f32>,
 }
 
 impl Accumulator {
     pub fn new(weights: &[f32], biases: &[f32]) -> Self {
-        let scale = compute_quantization_scale(weights);
-        let weights_i8 = quantize_embedding_weights(weights, scale);
-        let biases_i16 = quantize_embedding_biases(biases, scale);
+        let (scales, inv_scales) = compute_quantization_scales(weights);
+
+        let weights_i8 = quantize_embedding_weights(weights, &scales);
+        let biases_i16 = quantize_embedding_biases(biases, &scales);
 
         let mut buffer = [0i16; EMBEDDING_SIZE];
         buffer.copy_from_slice(&biases_i16);
@@ -47,7 +49,7 @@ impl Accumulator {
             biases: biases_i16,
             buffer,
             previous_input: Bitset::default(),
-            scale,
+            inv_scales,
         }
     }
 
@@ -103,16 +105,15 @@ impl Accumulator {
         }
     }
 
-    // Converts the accumulated i16 buffer into f32 activations with ReLU applied.
+    /// Converts the accumulated i16 buffer into f32 activations with ReLU applied.
     pub fn dequantize_and_relu(&self, output: &mut [f32; EMBEDDING_SIZE]) {
-        let scale = 1.0 / self.scale;
-        let scale_vec = SimdF32::splat(scale);
         let zeros = SimdF32::splat(0.0);
 
         let mut i = 0;
         while i + SIMD_WIDTH_F32 <= EMBEDDING_SIZE {
             let vals_i16 = &self.buffer[i..i + SIMD_WIDTH_F32];
             let vals_f32 = SimdF32::from_array(std::array::from_fn(|j| vals_i16[j] as f32));
+            let scale_vec = SimdF32::from_slice(&self.inv_scales[i..i + SIMD_WIDTH_F32]);
 
             let dequantized = vals_f32 * scale_vec;
             let activated = dequantized.simd_max(zeros); // ReLU
@@ -123,50 +124,78 @@ impl Accumulator {
 
         // Cleanup remaining outside SIMD width
         while i < EMBEDDING_SIZE {
-            output[i] = (self.buffer[i] as f32 * scale).max(0.0);
+            output[i] = (self.buffer[i] as f32 * self.inv_scales[i]).max(0.0);
             i += 1;
         }
     }
 }
 
-/// Computes a scale factor to quantize f32 weights to i8.
+/// Computes a per-output scale factor to quantize f32 weights to i8.
 /// Uses a percentile-based approach to avoid extreme outliers stretching the range.
-fn compute_quantization_scale(weights: &[f32]) -> f32 {
-    let max_abs_weight = weights.iter().map(|&w| w.abs()).fold(0.0f32, f32::max);
+fn compute_quantization_scales(weights: &[f32]) -> (Vec<f32>, Vec<f32>) {
+    let mut scales = Vec::with_capacity(EMBEDDING_SIZE);
+    let mut abs_weights = vec![0.0f32; NUM_FEATURES];
 
-    let mut abs_weights: Vec<f32> = weights.iter().map(|&w| w.abs()).collect();
-    abs_weights.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    // Index in the sorted abs-weight list used as the percentile cutoff.
+    let percentile_index = ((NUM_FEATURES - 1) as f32 * QUANTIZATION_PERCENTILE) as usize;
 
-    let percentile_idx = ((abs_weights.len() - 1) as f32 * QUANTIZATION_PERCENTILE) as usize;
-    let percentile_weight = abs_weights[percentile_idx];
+    // Compute the quantization scale for each accumulator neuron
+    for out_idx in 0..EMBEDDING_SIZE {
+        let row = &weights[out_idx * NUM_FEATURES..(out_idx + 1) * NUM_FEATURES];
+        for (i, &w) in row.iter().enumerate() {
+            abs_weights[i] = w.abs();
+        }
+        abs_weights.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap());
 
-    if percentile_weight > 0.0 {
-        (i8::MAX as f32) / percentile_weight
-    } else if max_abs_weight > 0.0 {
-        (i8::MAX as f32) / max_abs_weight
-    } else {
-        64.0
+        let max = *abs_weights.last().unwrap_or(&0.0);
+        let percentile_weight = abs_weights[percentile_index];
+
+        scales.push(if percentile_weight > 0.0 {
+            i8::MAX as f32 / percentile_weight
+        } else if max > 0.0 {
+            i8::MAX as f32 / max
+        } else {
+            64.0
+        });
     }
+
+    // so dequantization can multiply instead of divide
+    let inv_scales = scales
+        .iter()
+        .map(|&s| if s != 0.0 { 1.0 / s } else { 0.0 })
+        .collect();
+
+    (scales, inv_scales)
 }
 
 /// Quantizes embedding weights from f32 to i8 and transposes for cache-friendly access.
 /// Layout changes from [out_idx][feature_idx] to [feature_idx][out_idx].
-fn quantize_embedding_weights(weights: &[f32], scale: f32) -> Box<[i8]> {
-    let mut quantized = vec![0i8; NUM_FEATURES * EMBEDDING_SIZE].into_boxed_slice();
+fn quantize_embedding_weights(weights: &[f32], scales: &[f32]) -> Vec<i8> {
+    let mut quantized = vec![0i8; NUM_FEATURES * EMBEDDING_SIZE];
     for out_idx in 0..EMBEDDING_SIZE {
-        let src_row_offset = out_idx * NUM_FEATURES;
-        for feature_idx in 0..NUM_FEATURES {
-            let val = (weights[src_row_offset + feature_idx] * scale).round();
-            quantized[feature_idx * EMBEDDING_SIZE + out_idx] =
-                val.clamp(i8::MIN as f32, i8::MAX as f32) as i8;
+        let row = &weights[out_idx * NUM_FEATURES..(out_idx + 1) * NUM_FEATURES];
+        let scale = scales[out_idx];
+        for (feature_idx, &w) in row.iter().enumerate() {
+            quantized[feature_idx * EMBEDDING_SIZE + out_idx] = round_and_clip_to_i8(w * scale);
         }
     }
     quantized
 }
 
-fn quantize_embedding_biases(biases: &[f32], scale: f32) -> Box<[i16]> {
-    biases
-        .iter()
-        .map(|&b| (b * scale).round().clamp(i16::MIN as f32, i16::MAX as f32) as i16)
-        .collect()
+/// Quantizes embedding biases from f32 to i16 using per-output scales.
+fn quantize_embedding_biases(biases: &[f32], scales: &[f32]) -> Vec<i16> {
+    let mut quantized = vec![0i16; EMBEDDING_SIZE];
+    for i in 0..EMBEDDING_SIZE {
+        let scale = scales[i];
+        quantized[i] = round_and_clip_to_i16(biases[i] * scale);
+    }
+    quantized
+}
+
+fn round_and_clip_to_i8(val: f32) -> i8 {
+    val.round().clamp(i8::MIN as f32, i8::MAX as f32) as i8
+}
+
+fn round_and_clip_to_i16(val: f32) -> i16 {
+    val.round().clamp(i16::MIN as f32, i16::MAX as f32) as i16
 }


### PR DESCRIPTION
## Summary

Switches NNUE accumulator quantization from one global scale to pne per neuron in the accumulator. The idea being that a single global scale gets dominated by a few large weights and wastes i8 precision for many other neurons, while a scaling per neuron preserve more detail and reduce quantization errors.
