### PR TITLE
perf: bucket smoothness regularization

### DIFF
--- a/nnue/model.safetensors
+++ b/nnue/model.safetensors
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:404223016adc0fabf9b193542dbaac77678ad24c46d5e2e6b7dc77674676280a
+oid sha256:e1b3a8fc22a87ad0b496fb4b191fd40fbc1856cff370d6f66a257a5d0cfca5e4
 size 5265120

--- a/nnue/model.safetensors
+++ b/nnue/model.safetensors
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e1b3a8fc22a87ad0b496fb4b191fd40fbc1856cff370d6f66a257a5d0cfca5e4
+oid sha256:404223016adc0fabf9b193542dbaac77678ad24c46d5e2e6b7dc77674676280a
 size 5265120

--- a/nnue/src/network/inference.rs
+++ b/nnue/src/network/inference.rs
@@ -26,7 +26,7 @@ impl NNUENetwork {
         );
 
         let buckets: [OutputStack; OUTPUT_BUCKETS] = std::array::from_fn(|i| {
-            let bucket = &network.buckets[i];
+            let bucket = &network.eval_head.buckets[i];
             OutputStack {
                 hidden1: LinearLayer::from_candle_linear(&bucket.hidden1).unwrap(),
                 hidden2: LinearLayer::from_candle_linear(&bucket.hidden2).unwrap(),

--- a/nnue/src/network/mod.rs
+++ b/nnue/src/network/mod.rs
@@ -7,7 +7,7 @@ pub mod simd;
 use cozy_chess::Board;
 pub use inference::NNUENetwork;
 pub use linear::LinearLayer;
-pub use model::Network;
+pub use model::{EvalHead, Network};
 
 /// Size of the accumulator that input features are embedded into.
 pub const EMBEDDING_SIZE: usize = 1024;

--- a/nnue/src/network/model.rs
+++ b/nnue/src/network/model.rs
@@ -6,16 +6,34 @@ use crate::encoding::NUM_FEATURES;
 use super::{EMBEDDING_SIZE, HIDDEN_SIZE, OUTPUT_BUCKETS};
 
 /// Full-precision network for training and weight loading.
-/// Shared embedding layer with phase-specific output stacks.
 pub struct Network {
     pub embedding: Linear,
-    pub buckets: [OutputStack; OUTPUT_BUCKETS],
+    pub eval_head: EvalHead,
 }
 
 impl Network {
     pub fn new(vs: &VarBuilder) -> Result<Self> {
-        // Note: unwrap() is used here because layer creation only fails on programmer error
-        // (wrong dimensions). This keeps the array initialization clean.
+        Ok(Self {
+            embedding: linear(NUM_FEATURES, EMBEDDING_SIZE, vs.pp("embedding"))?,
+            eval_head: EvalHead::new(vs)?,
+        })
+    }
+
+    /// Forward pass returning all bucket outputs: [batch, OUTPUT_BUCKETS].
+    pub fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let embedding = x.apply(&self.embedding)?.relu()?;
+        self.eval_head.forward(&embedding)
+    }
+}
+
+/// Phase-specific evaluation head with one output stack per bucket.
+pub struct EvalHead {
+    pub buckets: [OutputStack; OUTPUT_BUCKETS],
+}
+
+impl EvalHead {
+    fn new(vs: &VarBuilder) -> Result<Self> {
+        // unwrap() is safe: layer creation only fails on programmer error (wrong dimensions).
         let buckets: [OutputStack; OUTPUT_BUCKETS] = std::array::from_fn(|i| {
             let bvs = vs.pp(format!("bucket_{}", i));
             OutputStack {
@@ -24,41 +42,30 @@ impl Network {
                 output: linear(HIDDEN_SIZE, 1, bvs.pp("output")).unwrap(),
             }
         });
-
-        Ok(Self {
-            embedding: linear(NUM_FEATURES, EMBEDDING_SIZE, vs.pp("embedding"))?,
-            buckets,
-        })
+        Ok(Self { buckets })
     }
 
-    /// Forward pass for training.
-    ///
-    /// Computes all bucket outputs, then gathers the correct one per sample.
-    /// During backprop, `gather` scatters gradients only to each sample's
-    /// selected bucket—unused buckets receive zero gradient for that sample.
-    #[inline]
-    pub fn forward(&self, x: &Tensor, buckets: &[usize]) -> Result<Tensor> {
-        let embedding_out = x.apply(&self.embedding)?.relu()?;
-
-        // Compute all bucket outputs: [batch, OUTPUT_BUCKETS]
-        let all_outputs: Vec<_> = self
+    fn forward(&self, embedding: &Tensor) -> Result<Tensor> {
+        let outputs: Vec<_> = self
             .buckets
             .iter()
-            .map(|b| b.forward(&embedding_out))
+            .map(|b| b.forward(embedding))
             .collect::<Result<_>>()?;
-        let stacked = Tensor::cat(&all_outputs, 1)?;
+        Tensor::cat(&outputs, 1)
+    }
 
-        // Select each sample's bucket output: [batch, 1]
+    /// Select each sample's bucket from the full output: [batch, 1].
+    pub fn gather(all_buckets: &Tensor, buckets: &[usize]) -> Result<Tensor> {
         let indices = Tensor::from_vec(
             buckets.iter().map(|&i| i as u32).collect::<Vec<_>>(),
             (buckets.len(), 1),
-            stacked.device(),
+            all_buckets.device(),
         )?;
-        stacked.gather(&indices, 1)
+        all_buckets.gather(&indices, 1)
     }
 }
 
-/// Hidden layers and output head for a single game phase.
+/// Hidden layers and output for a single game phase.
 pub struct OutputStack {
     pub hidden1: Linear,
     pub hidden2: Linear,

--- a/nnue/src/network/model.rs
+++ b/nnue/src/network/model.rs
@@ -61,7 +61,7 @@ impl EvalHead {
     }
 }
 
-/// Hidden layers and output for a single game phase.
+/// Hidden layers and output head for a single game phase.
 pub struct OutputStack {
     pub hidden1: Linear,
     pub hidden2: Linear,

--- a/nnue/src/network/model.rs
+++ b/nnue/src/network/model.rs
@@ -33,24 +33,20 @@ pub struct EvalHead {
 
 impl EvalHead {
     fn new(vs: &VarBuilder) -> Result<Self> {
-        // unwrap() is safe: layer creation only fails on programmer error (wrong dimensions).
-        let buckets: [OutputStack; OUTPUT_BUCKETS] = std::array::from_fn(|i| {
-            let bvs = vs.pp(format!("bucket_{}", i));
-            OutputStack {
-                hidden1: linear(EMBEDDING_SIZE, HIDDEN_SIZE, bvs.pp("hidden1")).unwrap(),
-                hidden2: linear(HIDDEN_SIZE, HIDDEN_SIZE, bvs.pp("hidden2")).unwrap(),
-                output: linear(HIDDEN_SIZE, 1, bvs.pp("output")).unwrap(),
-            }
-        });
-        Ok(Self { buckets })
+        let buckets = (0..OUTPUT_BUCKETS)
+            .map(|i| OutputStack::new(&vs.pp(format!("bucket_{i}"))))
+            .collect::<Result<Vec<_>>>()?;
+        Ok(Self {
+            buckets: buckets.try_into().ok().expect("correct bucket count"),
+        })
     }
 
     fn forward(&self, embedding: &Tensor) -> Result<Tensor> {
-        let outputs: Vec<_> = self
+        let outputs = self
             .buckets
             .iter()
             .map(|b| b.forward(embedding))
-            .collect::<Result<_>>()?;
+            .collect::<Result<Vec<_>>>()?;
         Tensor::cat(&outputs, 1)
     }
 
@@ -73,6 +69,14 @@ pub struct OutputStack {
 }
 
 impl OutputStack {
+    fn new(vs: &VarBuilder) -> Result<Self> {
+        Ok(Self {
+            hidden1: linear(EMBEDDING_SIZE, HIDDEN_SIZE, vs.pp("hidden1"))?,
+            hidden2: linear(HIDDEN_SIZE, HIDDEN_SIZE, vs.pp("hidden2"))?,
+            output: linear(HIDDEN_SIZE, 1, vs.pp("output"))?,
+        })
+    }
+
     fn forward(&self, input: &Tensor) -> Result<Tensor> {
         let h1 = input.apply(&self.hidden1)?.relu()?;
         let h2 = (h1.apply(&self.hidden2)? + &h1)?.relu()?;

--- a/training/src/bin/train/args.rs
+++ b/training/src/bin/train/args.rs
@@ -45,6 +45,10 @@ pub struct Args {
     #[arg(long, default_value_t = 0.3)]
     pub wdl: f64,
 
+    /// Bucket smoothness regularization weight (0.0 = disabled).
+    #[arg(long, default_value_t = 0.1)]
+    pub bucket_smoothness: f64,
+
     /// Save a randomly initialized model and exit.
     #[arg(long)]
     pub init_model: bool,

--- a/training/src/bin/train/training/evaluation.rs
+++ b/training/src/bin/train/training/evaluation.rs
@@ -4,13 +4,14 @@ use nnue::network::{EvalHead, Network};
 use std::error::Error;
 
 use crate::dataset::DataLoader;
-use crate::utils::loss::wdl_eval_loss;
+use crate::utils::loss::{bucket_smoothness_loss, wdl_eval_loss};
 
 pub fn evaluate(
     network: &Network,
     loader: DataLoader,
     device: &Device,
     wdl: f64,
+    bucket_smoothness: f64,
 ) -> Result<f32, Box<dyn Error>> {
     let mut total_loss = 0.0;
     let mut batches = 0;
@@ -28,7 +29,9 @@ pub fn evaluate(
         let buckets = network.forward(&x)?;
         let preds = EvalHead::gather(&buckets, &batch.buckets)?;
 
-        let loss = wdl_eval_loss(&preds, &y_eval, &y_outcome, wdl)?;
+        let loss_wdl_eval = wdl_eval_loss(&preds, &y_eval, &y_outcome, wdl)?;
+        let loss_bucket_smoothness = bucket_smoothness_loss(&buckets)? * bucket_smoothness;
+        let loss = (loss_wdl_eval + loss_bucket_smoothness)?;
 
         total_loss += loss.to_vec0::<f32>()?;
         batches += 1;

--- a/training/src/bin/train/training/evaluation.rs
+++ b/training/src/bin/train/training/evaluation.rs
@@ -1,6 +1,6 @@
 use candle_core::{Device, Tensor};
 use nnue::encoding::NUM_FEATURES;
-use nnue::network::Network;
+use nnue::network::{EvalHead, Network};
 use std::error::Error;
 
 use crate::dataset::DataLoader;
@@ -25,7 +25,9 @@ pub fn evaluate(
         let y_eval = Tensor::from_vec(batch.scores, (batch_len, 1), device)?;
         let y_outcome = Tensor::from_vec(batch.outcomes, (batch_len, 1), device)?;
 
-        let preds = network.forward(&x, &batch.buckets)?;
+        let buckets = network.forward(&x)?;
+        let preds = EvalHead::gather(&buckets, &batch.buckets)?;
+
         let loss = wdl_eval_loss(&preds, &y_eval, &y_outcome, wdl)?;
 
         total_loss += loss.to_vec0::<f32>()?;

--- a/training/src/bin/train/training/trainer.rs
+++ b/training/src/bin/train/training/trainer.rs
@@ -150,7 +150,6 @@ impl Trainer {
 
             let loss_wdl_eval = wdl_eval_loss(&preds, &y_eval, &y_outcome, self.wdl)?;
             let loss_bucket_smoothness = bucket_smoothness_loss(&buckets)? * self.bucket_smoothness;
-
             let loss = (loss_wdl_eval + loss_bucket_smoothness)?;
 
             self.optimizer.backward_step(&loss)?;
@@ -170,7 +169,13 @@ impl Trainer {
             self.workers,
             Arc::clone(shutdown),
         );
-        let val_loss = evaluate(&self.network, val_loader, &self.device, self.wdl)?;
+        let val_loss = evaluate(
+            &self.network,
+            val_loader,
+            &self.device,
+            self.wdl,
+            self.bucket_smoothness,
+        )?;
 
         progress.finish(val_loss, train_loss);
 
@@ -199,7 +204,13 @@ impl Trainer {
             self.workers,
             Arc::clone(shutdown),
         );
-        let test_loss = evaluate(&self.network, test_loader, &self.device, self.wdl)?;
+        let test_loss = evaluate(
+            &self.network,
+            test_loader,
+            &self.device,
+            self.wdl,
+            self.bucket_smoothness,
+        )?;
         log::info!("Test Loss: {:.6}", test_loss);
 
         Ok(test_loss)

--- a/training/src/bin/train/training/trainer.rs
+++ b/training/src/bin/train/training/trainer.rs
@@ -1,7 +1,7 @@
 use candle_core::{DType, Device, Tensor};
 use candle_nn::{AdamW, Optimizer, ParamsAdamW, VarBuilder, VarMap};
 use nnue::encoding::NUM_FEATURES;
-use nnue::network::Network;
+use nnue::network::{EvalHead, Network};
 use std::error::Error;
 use std::path::Path;
 use std::sync::Arc;
@@ -13,7 +13,7 @@ use crate::training::evaluation::evaluate;
 use crate::training::metrics::MetricsTracker;
 use crate::training::progress::TrainingProgressBar;
 use crate::utils::device::get_device;
-use crate::utils::loss::wdl_eval_loss;
+use crate::utils::loss::{bucket_smoothness_loss, wdl_eval_loss};
 
 /// Number of shards to keep loaded for training.
 const TRAIN_SHARDS: usize = 10;
@@ -32,6 +32,7 @@ pub struct Trainer {
     lr_decay: f64,
     patience: u64,
     wdl: f64,
+    bucket_smoothness: f64,
     model_path: String,
 }
 
@@ -62,6 +63,7 @@ impl Trainer {
             lr_decay: args.lr_decay,
             patience: args.patience,
             wdl,
+            bucket_smoothness: args.bucket_smoothness,
             model_path: model_path.to_string(),
         })
     }
@@ -77,6 +79,7 @@ impl Trainer {
             self.wdl * 100.0,
             (1.0 - self.wdl) * 100.0
         );
+        log::info!("Bucket smoothness: {}", self.bucket_smoothness);
 
         let mut metrics = MetricsTracker::new(self.patience);
 
@@ -142,8 +145,14 @@ impl Trainer {
             let y_eval = Tensor::from_vec(batch.scores, (batch_len, 1), &self.device)?;
             let y_outcome = Tensor::from_vec(batch.outcomes, (batch_len, 1), &self.device)?;
 
-            let preds = self.network.forward(&x, &batch.buckets)?;
-            let loss = wdl_eval_loss(&preds, &y_eval, &y_outcome, self.wdl)?;
+            let buckets = self.network.forward(&x)?;
+            let preds = EvalHead::gather(&buckets, &batch.buckets)?;
+
+            let loss = 
+            // WDL and eval loss
+            (wdl_eval_loss(&preds, &y_eval, &y_outcome, self.wdl)?
+            // Bucket smoothness loss
+            + bucket_smoothness_loss(&buckets)? * self.bucket_smoothness)?;
 
             self.optimizer.backward_step(&loss)?;
 

--- a/training/src/bin/train/training/trainer.rs
+++ b/training/src/bin/train/training/trainer.rs
@@ -148,11 +148,10 @@ impl Trainer {
             let buckets = self.network.forward(&x)?;
             let preds = EvalHead::gather(&buckets, &batch.buckets)?;
 
-            let loss = 
-            // WDL and eval loss
-            (wdl_eval_loss(&preds, &y_eval, &y_outcome, self.wdl)?
-            // Bucket smoothness loss
-            + bucket_smoothness_loss(&buckets)? * self.bucket_smoothness)?;
+            let loss_wdl_eval = wdl_eval_loss(&preds, &y_eval, &y_outcome, self.wdl)?;
+            let loss_bucket_smoothness = bucket_smoothness_loss(&buckets)? * self.bucket_smoothness;
+
+            let loss = (loss_wdl_eval + loss_bucket_smoothness)?;
 
             self.optimizer.backward_step(&loss)?;
 

--- a/training/src/bin/train/utils/loss.rs
+++ b/training/src/bin/train/utils/loss.rs
@@ -1,6 +1,7 @@
 use candle_core::{Result, Tensor};
 use candle_nn::loss::mse;
 use candle_nn::ops::sigmoid;
+use nnue::network::OUTPUT_BUCKETS;
 
 /// Sigmoid MSE loss blending eval and game outcome in win-probability space.
 ///
@@ -18,4 +19,12 @@ pub fn wdl_eval_loss(
     let target = ((target_outcome * wdl)? + (sigmoid_eval * (1.0 - wdl))?)?;
 
     mse(&sigmoid_output, &target)
+}
+
+/// Mean squared difference between adjacent bucket outputs.
+/// Regularizes bucket transitions to be smooth across game phases.
+pub fn bucket_smoothness_loss(all_buckets: &Tensor) -> Result<Tensor> {
+    let left = all_buckets.narrow(1, 0, OUTPUT_BUCKETS - 1)?;
+    let right = all_buckets.narrow(1, 1, OUTPUT_BUCKETS - 1)?;
+    (left - right)?.sqr()?.mean_all()
 }


### PR DESCRIPTION
## Summary

Added a bucket smoothness regularization term to the NNUE training loss. The motivation came from watching the eval during games. It would sit around +1.2, jump to +2.0, stay there for a while, then drop back to +1.2. Very steppy. I figured the output heads for adjacent game-phase buckets were learning pretty different functions, and the eval was just snapping between them at the transition points.

This is probably bad for search quality too, since the `improving` heuristic used for pruning decisions relies on the eval changing smoothly. if there are big artificial cliffs between buckets, it's going to misfire.

I tried adding a simple loss to penalize squared differences between adjacent bucket outputs. This nudges neighboring buckets to agree with each other without forcing them to be identical, so the eval transitions more gently across game phases.

And it worked surprisingly well actually. I trained some simple configs with different smoothness loss for 3 epochs on the 500m dataset used to train `1.1.0`, and:

```
--------------------------------------------------
Rank Name                             Elo        +/-       nElo        +/-      Games      Score       Draw           Ptnml(0-2)
   1 grail0.1                       30.77      18.94      45.45      27.80        600      54.4%      40.7% [12, 56, 122, 87, 23]
   2 grail0.2                        2.32      19.55       3.30      27.80        600      50.3%      36.3% [15, 81, 109, 75, 20]
   3 grail0.3                       -6.95      18.93     -10.22      27.80        600      49.0%      41.3% [20, 71, 124, 71, 14]
   4 grail0.0                      -26.11      18.92     -38.54      27.80        600      46.2%      38.3% [21, 89, 115, 64, 11]
--------------------------------------------------
```

So that is pretty neat. I will re-train with `0.1` until early stop using the same data and check against `next`