### PR TITLE
perf: scale reductions by history and continuation history

### DIFF
--- a/search/src/config.rs
+++ b/search/src/config.rs
@@ -87,9 +87,7 @@ define_config!(
     (aspiration_score_divisor: i32, "Aspiration Score Divisor", UciOptionType::Spin { min: 1024, max: 65536 }, 16384, cfg!(feature = "tuning")),
 
     (history_max_value: i32, "History Max Value", UciOptionType::Spin { min: 128, max: 1024 }, 512, cfg!(feature = "tuning")),
-    (history_reduction_threshold: i16, "History Reduction Threshold", UciOptionType::Spin { min: -512, max: 512 }, -8, cfg!(feature = "tuning")),
     (history_prune_threshold: i16, "History Prune Threshold", UciOptionType::Spin { min: -512, max: 512 }, -64, cfg!(feature = "tuning")),
-    (history_min_move_index: i32, "History Min Move Index", UciOptionType::Spin { min: 1, max: 10 }, 5, cfg!(feature = "tuning")),
     (history_bonus_multiplier: i32, "History Bonus Multiplier", UciOptionType::Spin { min: 0, max: 30 }, 13, cfg!(feature = "tuning")),
     (history_malus_multiplier: i32, "History Malus Multiplier", UciOptionType::Spin { min: 0, max: 30 }, 4, cfg!(feature = "tuning")),
 
@@ -112,12 +110,14 @@ define_config!(
 
     (reduction_cut_node: u16, "Reduction Cut Node", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
     (reduction_not_improving: u16, "Reduction Not Improving", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
-    (reduction_bad_history: u16, "Reduction Bad History", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
     (anti_reduction_near_root: u16, "Anti Reduction Near Root", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
     (anti_reduction_pv_node: u16, "Anti Reduction PV Node", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
     (anti_reduction_tactical: u16, "Anti Reduction Tactical", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
     (anti_reduction_threat: u16, "Anti Reduction Threat", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
     (anti_reduction_check: u16, "Anti Reduction Check", UciOptionType::Spin { min: 0, max: 4096 }, 1500, cfg!(feature = "tuning")),
+
+    (reduction_history_divisor: i32, "Reduction History Divisor", UciOptionType::Spin { min: 64, max: 16384 }, 2048, cfg!(feature = "tuning")),
+    (reduction_cont_hist_divisor: i32, "Reduction Cont Hist Divisor", UciOptionType::Spin { min: 64, max: 16384 }, 8192, cfg!(feature = "tuning")),
 
     (nmp_min_depth: u8, "NMP Min Depth", UciOptionType::Spin { min: 2, max: 10 }, 4, cfg!(feature = "tuning")),
     (nmp_base_reduction: u8, "NMP Base Reduction", UciOptionType::Spin { min: 1, max: 10 }, 2, cfg!(feature = "tuning")),

--- a/search/src/history/history_heuristic.rs
+++ b/search/src/history/history_heuristic.rs
@@ -14,9 +14,7 @@ pub struct HistoryHeuristic {
     history: Vec<i16>,
 
     max_history: i32,
-    reduction_threshold: i16,
     prune_threshold: i16,
-    min_move_index: i32,
 
     bonus_multiplier: i32,
     malus_multiplier: i32,
@@ -25,9 +23,7 @@ pub struct HistoryHeuristic {
 impl HistoryHeuristic {
     pub fn new(
         max_history: i32,
-        reduction_threshold: i16,
         prune_threshold: i16,
-        min_move_index: i32,
         bonus_multiplier: i32,
         malus_multiplier: i32,
     ) -> Self {
@@ -35,9 +31,7 @@ impl HistoryHeuristic {
             history: vec![0; HISTORY_SIZE],
 
             max_history,
-            reduction_threshold,
             prune_threshold,
-            min_move_index,
 
             bonus_multiplier,
             malus_multiplier,
@@ -46,9 +40,7 @@ impl HistoryHeuristic {
 
     pub fn configure(&mut self, config: &EngineConfig) {
         self.max_history = config.history_max_value.value;
-        self.reduction_threshold = config.history_reduction_threshold.value;
         self.prune_threshold = config.history_prune_threshold.value;
-        self.min_move_index = config.history_min_move_index.value;
 
         self.bonus_multiplier = config.history_bonus_multiplier.value;
         self.malus_multiplier = config.history_malus_multiplier.value;
@@ -58,9 +50,7 @@ impl HistoryHeuristic {
 
     pub fn matches_config(&self, config: &EngineConfig) -> bool {
         self.max_history == config.history_max_value.value
-            && self.reduction_threshold == config.history_reduction_threshold.value
             && self.prune_threshold == config.history_prune_threshold.value
-            && self.min_move_index == config.history_min_move_index.value
             && self.bonus_multiplier == config.history_bonus_multiplier.value
             && self.malus_multiplier == config.history_malus_multiplier.value
     }
@@ -92,10 +82,6 @@ impl HistoryHeuristic {
         let source_stride = Square::NUM;
 
         color_idx * color_stride + source_idx * source_stride + dest_idx
-    }
-
-    pub fn reduction_threshold(&self) -> i16 {
-        self.reduction_threshold
     }
 
     pub fn prune_threshold(&self) -> i16 {

--- a/search/src/searcher/mod.rs
+++ b/search/src/searcher/mod.rs
@@ -104,7 +104,7 @@ impl Searcher {
 
             search_stack: SearchStack::with_capacity(MAX_DEPTH),
 
-            history_heuristic: HistoryHeuristic::new(1, 1, 1, 1, 1, 1),
+            history_heuristic: HistoryHeuristic::new(1, 1, 1, 1),
             capture_history: CaptureHistory::new(1, 1, 1),
             continuation_history: Box::new(ContinuationHistory::new(1, 1, 1, 1)),
 

--- a/search/src/searcher/reduction.rs
+++ b/search/src/searcher/reduction.rs
@@ -1,7 +1,6 @@
-use cozy_chess::Move;
 use utils::{FracPly, Node, creates_threat, evades_threat};
 
-use crate::{lmr::LmrTable, utils::near_root};
+use crate::utils::near_root;
 
 use super::Searcher;
 
@@ -26,18 +25,14 @@ impl Searcher {
         move_index: i32,
         parent: &Node,
         child: &Node,
-        m: Move,
-        lmr_table: &LmrTable,
+        hist: i16,
+        cont_hist: i16,
     ) -> Reduction {
         if is_pv_move {
             return Reduction::Reduce(0);
         }
 
-        let hist = self
-            .history_heuristic
-            .get(parent.side_to_move(), m.from, m.to);
-
-        let mut reduction = lmr_table.get(depth, move_index);
+        let mut reduction = self.lmr.get(depth, move_index);
 
         // Reduce more
         if parent.is_cut() {
@@ -45,11 +40,21 @@ impl Searcher {
         }
         if !is_improving {
             reduction += FracPly(self.config.reduction_not_improving.value);
-
-            if !is_capture && hist < self.history_heuristic.reduction_threshold() {
-                reduction += FracPly(self.config.reduction_bad_history.value);
-            }
         }
+
+        if !is_capture {
+            scale_by_history(
+                &mut reduction,
+                hist,
+                self.config.reduction_history_divisor.value,
+            );
+        }
+
+        scale_by_history(
+            &mut reduction,
+            cont_hist,
+            self.config.reduction_cont_hist_divisor.value,
+        );
 
         // Reduce less
         if reduction > FracPly(0) {
@@ -83,5 +88,14 @@ impl Searcher {
         }
 
         Reduction::Reduce(r)
+    }
+}
+
+fn scale_by_history(reduction: &mut FracPly, score: i16, divisor: i32) {
+    let delta = score as i32 * FracPly::ONE as i32 / divisor;
+    if delta > 0 {
+        *reduction -= FracPly(delta.min(u16::MAX as i32) as u16);
+    } else {
+        *reduction += FracPly((-delta).min(u16::MAX as i32) as u16);
     }
 }

--- a/search/src/searcher/search.rs
+++ b/search/src/searcher/search.rs
@@ -11,6 +11,7 @@ use utils::{Node, NodeType, has_legal_moves};
 
 use crate::{
     aspiration::Pass,
+    history::PieceTo,
     move_ordering::{MAX_CAPTURES, MAX_QUIETS, MainMoveGenerator},
     pv::PvLine,
     result::SearchResult,
@@ -548,6 +549,14 @@ impl Searcher {
             return None;
         }
 
+        let hist = self.history_heuristic.get(moved_color, m.from, m.to);
+        let cont_hist = {
+            let prev_moves = self
+                .continuation_history
+                .get_prev_moves(self.search_stack.as_slice());
+            let pt = PieceTo::new(moved_color, moved_piece, m.to);
+            self.continuation_history.get(&prev_moves, pt)
+        };
         let reduction = match self.get_reduction(
             ply,
             depth,
@@ -558,8 +567,8 @@ impl Searcher {
             move_index,
             node,
             &child,
-            m,
-            &self.lmr,
+            hist,
+            cont_hist,
         ) {
             Reduction::Reduce(r) => r,
             Reduction::Prune => return None,


### PR DESCRIPTION
## Summary

Replaced the binary history threshold in reductions with continuous scaling. Now the reduction slides proportionally with the history score, so a move with history +500 gets meaningfully less reduction than one at +100, and a move at -300 gets reduced harder than one at -50.

Also added continuation history as another reduction signal.
Also some minor refactorings.