### PR TITLE
perf: use capture history for reduction scaling on captures

### DIFF
--- a/search/src/searcher/reduction.rs
+++ b/search/src/searcher/reduction.rs
@@ -42,13 +42,12 @@ impl Searcher {
             reduction += FracPly(self.config.reduction_not_improving.value);
         }
 
-        scale_by_history(
+        history_reduction(
             &mut reduction,
             hist,
             self.config.reduction_history_divisor.value,
         );
-
-        scale_by_history(
+        history_reduction(
             &mut reduction,
             cont_hist,
             self.config.reduction_cont_hist_divisor.value,
@@ -89,11 +88,12 @@ impl Searcher {
     }
 }
 
-fn scale_by_history(reduction: &mut FracPly, score: i16, divisor: i32) {
-    let delta = score as i32 * FracPly::ONE as i32 / divisor;
-    if delta > 0 {
-        *reduction -= FracPly(delta.min(u16::MAX as i32) as u16);
+fn history_reduction(reduction: &mut FracPly, score: i16, divisor: i32) {
+    let delta = FracPly((score.abs() as i32 * FracPly::ONE as i32 / divisor) as u16);
+
+    if score > 0 {
+        *reduction -= delta
     } else {
-        *reduction += FracPly((-delta).min(u16::MAX as i32) as u16);
+        *reduction += delta
     }
 }

--- a/search/src/searcher/reduction.rs
+++ b/search/src/searcher/reduction.rs
@@ -42,13 +42,11 @@ impl Searcher {
             reduction += FracPly(self.config.reduction_not_improving.value);
         }
 
-        if !is_capture {
-            scale_by_history(
-                &mut reduction,
-                hist,
-                self.config.reduction_history_divisor.value,
-            );
-        }
+        scale_by_history(
+            &mut reduction,
+            hist,
+            self.config.reduction_history_divisor.value,
+        );
 
         scale_by_history(
             &mut reduction,

--- a/search/src/searcher/search.rs
+++ b/search/src/searcher/search.rs
@@ -549,7 +549,11 @@ impl Searcher {
             return None;
         }
 
-        let hist = self.history_heuristic.get(moved_color, m.from, m.to);
+        let hist = if is_cap {
+            self.capture_history.get(node.board(), m)
+        } else {
+            self.history_heuristic.get(moved_color, m.from, m.to)
+        };
         let cont_hist = {
             let prev_moves = self
                 .continuation_history


### PR DESCRIPTION
I was just adding continuous history scaling to reductions #183, and it struck me that captures were being left out. So hist is now set to capture history if capture, and it goes through the same loop.