### PR TITLE
perf: fix history reduction scaling done properly this time

### DIFF
--- a/search/src/config.rs
+++ b/search/src/config.rs
@@ -110,14 +110,16 @@ define_config!(
 
     (reduction_cut_node: u16, "Reduction Cut Node", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
     (reduction_not_improving: u16, "Reduction Not Improving", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
+    (reduction_history_divisor: i32, "Reduction History Divisor", UciOptionType::Spin { min: 64, max: 16384 }, 987, cfg!(feature = "tuning")),
+    (reduction_capture_history_divisor: i32, "Reduction Capture History Divisor", UciOptionType::Spin { min: 64, max: 16384 }, 987, cfg!(feature = "tuning")),
+    (reduction_capture_value_divisor: i32, "Reduction Capture Value Divisor", UciOptionType::Spin { min: 256, max: 16384 }, 2048, cfg!(feature = "tuning")),
+    (reduction_cont_hist_divisor: i32, "Reduction Cont Hist Divisor", UciOptionType::Spin { min: 64, max: 16384 }, 5030, cfg!(feature = "tuning")),
+
     (anti_reduction_near_root: u16, "Anti Reduction Near Root", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
     (anti_reduction_pv_node: u16, "Anti Reduction PV Node", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
     (anti_reduction_tactical: u16, "Anti Reduction Tactical", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
     (anti_reduction_threat: u16, "Anti Reduction Threat", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
     (anti_reduction_check: u16, "Anti Reduction Check", UciOptionType::Spin { min: 0, max: 4096 }, 1500, cfg!(feature = "tuning")),
-
-    (reduction_history_divisor: i32, "Reduction History Divisor", UciOptionType::Spin { min: 64, max: 16384 }, 987, cfg!(feature = "tuning")),
-    (reduction_cont_hist_divisor: i32, "Reduction Cont Hist Divisor", UciOptionType::Spin { min: 64, max: 16384 }, 5030, cfg!(feature = "tuning")),
 
     (nmp_min_depth: u8, "NMP Min Depth", UciOptionType::Spin { min: 2, max: 10 }, 4, cfg!(feature = "tuning")),
     (nmp_base_reduction: u8, "NMP Base Reduction", UciOptionType::Spin { min: 1, max: 10 }, 2, cfg!(feature = "tuning")),

--- a/search/src/config.rs
+++ b/search/src/config.rs
@@ -110,10 +110,10 @@ define_config!(
 
     (reduction_cut_node: u16, "Reduction Cut Node", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
     (reduction_not_improving: u16, "Reduction Not Improving", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
-    (reduction_history_divisor: i32, "Reduction History Divisor", UciOptionType::Spin { min: 64, max: 16384 }, 987, cfg!(feature = "tuning")),
-    (reduction_capture_history_divisor: i32, "Reduction Capture History Divisor", UciOptionType::Spin { min: 64, max: 16384 }, 987, cfg!(feature = "tuning")),
+    (reduction_history_divisor: i32, "Reduction History Divisor", UciOptionType::Spin { min: 64, max: 16384 }, 1004, cfg!(feature = "tuning")),
+    (reduction_capture_history_divisor: i32, "Reduction Capture History Divisor", UciOptionType::Spin { min: 64, max: 16384 }, 973, cfg!(feature = "tuning")),
     (reduction_capture_value_divisor: i32, "Reduction Capture Value Divisor", UciOptionType::Spin { min: 256, max: 16384 }, 2048, cfg!(feature = "tuning")),
-    (reduction_cont_hist_divisor: i32, "Reduction Cont Hist Divisor", UciOptionType::Spin { min: 64, max: 16384 }, 5030, cfg!(feature = "tuning")),
+    (reduction_cont_hist_divisor: i32, "Reduction Cont Hist Divisor", UciOptionType::Spin { min: 64, max: 16384 }, 5011, cfg!(feature = "tuning")),
 
     (anti_reduction_near_root: u16, "Anti Reduction Near Root", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
     (anti_reduction_pv_node: u16, "Anti Reduction PV Node", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),

--- a/search/src/searcher/reduction.rs
+++ b/search/src/searcher/reduction.rs
@@ -1,4 +1,5 @@
-use utils::{FracPly, Node, creates_threat, evades_threat};
+use cozy_chess::Piece;
+use utils::{FracPly, Node, creates_threat, evades_threat, piece_value};
 
 use crate::utils::near_root;
 
@@ -20,7 +21,7 @@ impl Searcher {
         depth: u8,
         is_pv_move: bool,
         is_improving: bool,
-        is_capture: bool,
+        captured: Option<Piece>,
         is_promotion: bool,
         move_index: i32,
         parent: &Node,
@@ -42,16 +43,29 @@ impl Searcher {
             reduction += FracPly(self.config.reduction_not_improving.value);
         }
 
-        history_reduction(
-            &mut reduction,
-            hist,
-            self.config.reduction_history_divisor.value,
-        );
-        history_reduction(
-            &mut reduction,
-            cont_hist,
-            self.config.reduction_cont_hist_divisor.value,
-        );
+        if let Some(victim) = captured {
+            history_reduction(
+                &mut reduction,
+                piece_value(victim),
+                self.config.reduction_capture_value_divisor.value,
+            );
+            history_reduction(
+                &mut reduction,
+                hist,
+                self.config.reduction_capture_history_divisor.value,
+            );
+        } else {
+            history_reduction(
+                &mut reduction,
+                hist,
+                self.config.reduction_history_divisor.value,
+            );
+            history_reduction(
+                &mut reduction,
+                cont_hist,
+                self.config.reduction_cont_hist_divisor.value,
+            );
+        }
 
         // Reduce less
         if reduction > FracPly(0) {
@@ -64,7 +78,7 @@ impl Searcher {
             if parent.in_check() || child.in_check() {
                 reduction -= FracPly(self.config.anti_reduction_check.value);
             }
-            if is_capture || is_promotion {
+            if captured.is_some() || is_promotion {
                 reduction -= FracPly(self.config.anti_reduction_tactical.value);
             }
             if creates_threat(parent, child) || evades_threat(parent, child) {
@@ -76,7 +90,7 @@ impl Searcher {
 
         // Prune when bad history if it would barely search anyway
         let reduced_depth = depth.saturating_sub(r);
-        if !is_capture
+        if captured.is_none()
             && !is_improving
             && hist < self.history_heuristic.prune_threshold()
             && reduced_depth <= 1

--- a/search/src/searcher/search.rs
+++ b/search/src/searcher/search.rs
@@ -7,7 +7,7 @@ use uci::{
     UciOutput,
     commands::{GoParams, Info, Score},
 };
-use utils::{Node, NodeType, has_legal_moves};
+use utils::{Node, NodeType, captured_piece, has_legal_moves};
 
 use crate::{
     aspiration::Pass,
@@ -549,24 +549,26 @@ impl Searcher {
             return None;
         }
 
-        let hist = if is_cap {
-            self.capture_history.get(node.board(), m)
+        let (captured, hist, cont_hist) = if is_cap {
+            let captured = captured_piece(node.board(), m);
+            let hist = self.capture_history.get(node.board(), m);
+            (captured, hist, 0)
         } else {
-            self.history_heuristic.get(moved_color, m.from, m.to)
-        };
-        let cont_hist = {
+            let hist = self.history_heuristic.get(moved_color, m.from, m.to);
             let prev_moves = self
                 .continuation_history
                 .get_prev_moves(self.search_stack.as_slice());
             let pt = PieceTo::new(moved_color, moved_piece, m.to);
-            self.continuation_history.get(&prev_moves, pt)
+            let cont_hist = self.continuation_history.get(&prev_moves, pt);
+            (None, hist, cont_hist)
         };
+
         let reduction = match self.get_reduction(
             ply,
             depth,
             is_pv_move,
             is_improving,
-            is_cap,
+            captured,
             is_promotion,
             move_index,
             node,


### PR DESCRIPTION
Fix history reduction scaling from #183 and #184. Those had captures and quiets sharing
the same divisor and were routing continuation history (only trained on quiets) into capture
reductions.