### PR TITLE
perf: nnue king attacks

### DIFF
--- a/nnue/model.safetensors
+++ b/nnue/model.safetensors
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e1b3a8fc22a87ad0b496fb4b191fd40fbc1856cff370d6f66a257a5d0cfca5e4
+oid sha256:30d332d0795d50a35dbc89ebad0997b457f5982eeb63060d890bc4aaa807f006
 size 5265120

--- a/utils/src/board_metrics.rs
+++ b/utils/src/board_metrics.rs
@@ -1,6 +1,6 @@
 use cozy_chess::{
-    BitBoard, Board, Color, Piece, get_bishop_moves, get_knight_moves, get_pawn_attacks,
-    get_rook_moves,
+    BitBoard, Board, Color, Piece, get_bishop_moves, get_king_moves, get_knight_moves,
+    get_pawn_attacks, get_rook_moves,
 };
 
 /// Precomputed board metrics for evaluation.
@@ -53,6 +53,9 @@ impl BoardMetrics {
         let white_non_pawns = white_minors | white_majors;
         let black_non_pawns = black_minors | black_majors;
 
+        let white_king = board.king(Color::White);
+        let black_king = board.king(Color::Black);
+
         let (white_attacks, black_threats) = compute(
             Color::White,
             white_pawns,
@@ -60,6 +63,7 @@ impl BoardMetrics {
             white_bishops,
             white_rooks,
             white_queens,
+            white_king,
             black_non_pawns,
             black_majors,
             black_queens,
@@ -73,6 +77,7 @@ impl BoardMetrics {
             black_bishops,
             black_rooks,
             black_queens,
+            black_king,
             white_non_pawns,
             white_majors,
             white_queens,
@@ -100,6 +105,7 @@ fn compute(
     bishops: BitBoard,
     rooks: BitBoard,
     queens: BitBoard,
+    king: cozy_chess::Square,
     opponent_non_pawns: BitBoard,
     opponent_majors: BitBoard,
     opponent_queens: BitBoard,
@@ -163,6 +169,8 @@ fn compute(
             attacks |= squares;
         }
     }
+
+    attacks |= get_king_moves(king);
 
     (attacks, threats)
 }


### PR DESCRIPTION
## Summary

Added king moves to the attack bitboards in `BoardMetrics`. Previously only pawn, knight, bishop, rook, and queen attacks were included.

Retrained NNUE model (of course)

This also sets us up for custom move ordering where the attack bitboard will contain king attacks, which is what i suppose i will re-use.