### PR TITLE
perf: re-add nmp verification

### DIFF
--- a/search/src/config.rs
+++ b/search/src/config.rs
@@ -124,6 +124,7 @@ define_config!(
     (nmp_base_reduction: u8, "NMP Base Reduction", UciOptionType::Spin { min: 1, max: 10 }, 2, cfg!(feature = "tuning")),
     (nmp_depth_divisor: u8, "NMP Depth Divisor", UciOptionType::Spin { min: 1, max: 10 }, 3, cfg!(feature = "tuning")),
     (nmp_eval_margin: i16, "NMP Eval Margin", UciOptionType::Spin { min: 0, max: 500 }, 200, cfg!(feature = "tuning")),
+    (nmp_verify_depth: u8, "NMP Verify Depth", UciOptionType::Spin { min: 8, max: 24 }, 16, cfg!(feature = "tuning")),
 
     (lmp_max_depth: u8, "LMP Max Depth", UciOptionType::Spin { min: 0, max: 20 }, 8, cfg!(feature = "tuning")),
     (lmp_base_moves: i32, "LMP Base Moves", UciOptionType::Spin { min: 1, max: 10 }, 2, cfg!(feature = "tuning")),

--- a/search/src/searcher/pruning.rs
+++ b/search/src/searcher/pruning.rs
@@ -135,7 +135,7 @@ impl Searcher {
     }
 
     /// Null move pruning: give opponent a free move; if we still beat beta, prune the subtree.
-    /// Includes verification search at low depths to avoid zugzwang.
+    /// Includes verification search at high depths to avoid zugzwang.
     ///
     /// <https://www.chessprogramming.org/Null_Move_Pruning>
     pub(super) fn try_null_move_prune(
@@ -180,29 +180,42 @@ impl Searcher {
 
         // Null window around beta for the null move search
         let null_bounds = Bounds::null(-bounds.beta);
+        let reduced_depth = depth.saturating_sub(r + 1);
 
         // Do a reduced depth null search to check if our position is still good enough
         self.search_stack.push_node(&nm_child);
-        let reduced_child_depth = depth.saturating_sub(r + 1);
-        let score = self.search_node(&nm_child, reduced_child_depth, ply + 1, null_bounds, false);
+        let null_value = -self.search_node(&nm_child, reduced_depth, ply + 1, null_bounds, false);
         self.search_stack.pop();
 
-        // If opponent couldn't beat beta even with a free move, position is strong enough to prune
-        if -score >= bounds.beta {
-            self.shared.tt().store(
-                node.hash(),
-                ply,
-                depth.saturating_sub(r),
-                bounds.beta,
-                None,
-                bounds.alpha,
-                bounds.beta,
-                None,
-            );
-            return Some(bounds.beta);
+        if null_value < bounds.beta || null_value.abs() >= NEAR_MATE_VALUE {
+            return None;
         }
 
-        None
+        // At high depths, verify the null-move result with NMP disabled.
+        if depth >= self.config.nmp_verify_depth.value {
+            let v = self.search_node(
+                node,
+                reduced_depth,
+                ply,
+                Bounds::null(bounds.beta - 1),
+                false,
+            );
+            if v < bounds.beta {
+                return None;
+            }
+        }
+
+        self.shared.tt().store(
+            node.hash(),
+            ply,
+            depth.saturating_sub(r),
+            bounds.beta,
+            None,
+            bounds.alpha,
+            bounds.beta,
+            None,
+        );
+        Some(bounds.beta)
     }
 
     /// Reverse futility pruning: if static eval - margin >= beta, the position is too good to search.

--- a/search/src/searcher/pruning.rs
+++ b/search/src/searcher/pruning.rs
@@ -192,6 +192,7 @@ impl Searcher {
         }
 
         // At high depths, verify the null-move result with NMP disabled.
+        // (no push_node needed = same position/ply)
         if depth >= self.config.nmp_verify_depth.value {
             let v = self.search_node(
                 node,
@@ -210,7 +211,7 @@ impl Searcher {
             ply,
             depth.saturating_sub(r),
             bounds.beta,
-            None,
+            static_eval,
             bounds.alpha,
             bounds.beta,
             None,


### PR DESCRIPTION
## Summary

Re-added NMP verification search. No wonder removing it "worked" in fae2313... The old implementation ran verification at _lower_ depths, which is backwards. Verification is meant to catch zugzwang at deep nodes where a bad null-move cutoff is expensive (duuh).

Also added a near-mate guard that rejects null-move pruning when the score is within mating range, since those scores are unreliable from a null-move search. Might have taken some inspiration from Stockfish here (_insert guilt here_). Though I'm sure no one will read this to verify that claim.