### PR TITLE
feat: zero-knowledge net

### DIFF
--- a/nnue/model.safetensors
+++ b/nnue/model.safetensors
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:30d332d0795d50a35dbc89ebad0997b457f5982eeb63060d890bc4aaa807f006
+oid sha256:3243d96961481ab819e0e5bf46add060626b8fc43d4b7e59cb2759fe41467ef6
 size 5265120

--- a/nnue/model.safetensors
+++ b/nnue/model.safetensors
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3243d96961481ab819e0e5bf46add060626b8fc43d4b7e59cb2759fe41467ef6
+oid sha256:a62be4ba37dd2976c9cd3230c5c19f2b1c2b013325f68c6a78aa08cc7b53eb66
 size 5265120

--- a/nnue/model.safetensors
+++ b/nnue/model.safetensors
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ac140a69c69174b81b51d4139dfaa66f919387fcd7d3f280013245880973e9a1
+oid sha256:5d83164e0ceebcac6f4dadc3e836661756d86fcc76af752506c5acc1599caf56
 size 5265120

--- a/nnue/model.safetensors
+++ b/nnue/model.safetensors
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7fbdb33ba9f04d070b117bae3deeecb1faef9f637ade3351a5fcfec7eca3bfff
+oid sha256:ac140a69c69174b81b51d4139dfaa66f919387fcd7d3f280013245880973e9a1
 size 5265120

--- a/nnue/model.safetensors
+++ b/nnue/model.safetensors
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a62be4ba37dd2976c9cd3230c5c19f2b1c2b013325f68c6a78aa08cc7b53eb66
+oid sha256:fca77dc58b3d268f6a80f3099d57ddf27eec4ed01842157fdf58c33d88aa3b6a
 size 5265120

--- a/nnue/model.safetensors
+++ b/nnue/model.safetensors
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fca77dc58b3d268f6a80f3099d57ddf27eec4ed01842157fdf58c33d88aa3b6a
+oid sha256:1170e0f6c506f1dfc2a90e2e856bc4bf35439adeb25b71b7e8c7314953122316
 size 5265120

--- a/nnue/model.safetensors
+++ b/nnue/model.safetensors
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5d83164e0ceebcac6f4dadc3e836661756d86fcc76af752506c5acc1599caf56
+oid sha256:9e5b6b7c1ef16b2fbd51f7105667b0eadd0298030914db43b4c814f9e41058d3
 size 5265120

--- a/nnue/model.safetensors
+++ b/nnue/model.safetensors
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1170e0f6c506f1dfc2a90e2e856bc4bf35439adeb25b71b7e8c7314953122316
+oid sha256:7fbdb33ba9f04d070b117bae3deeecb1faef9f637ade3351a5fcfec7eca3bfff
 size 5265120

--- a/training/src/bin/train/args.rs
+++ b/training/src/bin/train/args.rs
@@ -14,7 +14,7 @@ pub struct Args {
     pub learning_rate: f64,
 
     /// Maximum number of training epochs.
-    #[arg(long, default_value_t = 100)]
+    #[arg(long, default_value_t = 200)]
     pub epochs: usize,
 
     /// Number of data loader workers.
@@ -22,7 +22,7 @@ pub struct Args {
     pub workers: usize,
 
     /// Fraction of data for validation set.
-    #[arg(long, default_value_t = 0.1)]
+    #[arg(long, default_value_t = 0.05)]
     pub val_ratio: f64,
 
     /// Fraction of data for test set.
@@ -34,7 +34,7 @@ pub struct Args {
     pub lr_decay: f64,
 
     /// Epochs without improvement before early stopping.
-    #[arg(long, default_value_t = 2)]
+    #[arg(long, default_value_t = 5)]
     pub patience: u64,
 
     /// Size of each shard in megabytes.


### PR DESCRIPTION
Training a net from scratch using zero prior knowledge, so a random net iteratively improved through self-play using WDL and its own search as it gets stronger.

### Process

<img width="1876" height="757" alt="image" src="https://github.com/user-attachments/assets/e91397c5-8f3d-4952-8525-4ace26d8b02e" />

1. **Random net:** Initialize a random net with truly zero knowledge. 
2. **Seed net (iteration 0):** Generate self-play data from the random net, then train a seed net on 100% WDL labels from that data.
3. **Iterative training:** Each subsequent iteration trains on data generated from the previous iteration (_not all prior iterations_), using a blend of 50% WDL + 50% search evals (depth 8).
4. **Plateau tuning:** Once progress plateaus, experiment with lowering the WDL blend.

### Baseline

Each iteration is tested against the `next` branch (v1.1.0+), which is roughly +23 Elo over `main` (v1.1.0). `main` has a known Elo of **3322** on [CCRL](https://computerchess.org.uk/4040/cgi/compare_engines.cgi?family=Grail), putting `next` at an estimated **3345**.

```
--------------------------------------------------
Results of grail-next vs grail-main (8+0.08, 1t, 256MB, UHO_Lichess_4852_v1.epd):
Elo: 22.73 +/- 8.40, nElo: 33.76 +/- 12.43
LOS: 100.00 %, DrawRatio: 40.87 %, PairsRatio: 1.33
Games: 3000, Wins: 1011, Losses: 815, Draws: 1174, Points: 1598.0 (53.27 %)
Ptnml(0-2): [48, 332, 613, 390, 117], WL/DD Ratio: 1.71
--------------------------------------------------
```

### Progress

<img width="909" height="323" alt="Elo" src="https://github.com/user-attachments/assets/57ffda5b-bb6d-4064-950a-83462770c41b" />
<img width="909" height="323" alt="Positions (m)" src="https://github.com/user-attachments/assets/f428c5ee-7b19-4f69-bf9f-16d3629a92bf" />
<img width="909" height="323" alt="Games (m)" src="https://github.com/user-attachments/assets/1da22946-0048-4167-87a0-f322e00dd661" />
