### PR TITLE
perf: prune quiet evasions in qsearch

### DIFF
--- a/search/src/searcher/quiescence.rs
+++ b/search/src/searcher/quiescence.rs
@@ -1,4 +1,4 @@
-use crate::scores::{MATE_VALUE, SCORE_INF};
+use crate::scores::{MATE_SCORE_BOUND, MATE_VALUE, SCORE_INF};
 use arrayvec::ArrayVec;
 use cozy_chess::{Board, Color, Move, Piece, Rank};
 use utils::{QUEEN_VALUE, make_move, piece_value};
@@ -124,6 +124,14 @@ impl Searcher {
         let mut moves = QMoveGenerator::new(node, &self.capture_history);
 
         while let Some(mv) = moves.next() {
+            // Skip quiet evasions once we know we're not getting mated.
+            // Without this, check chains explode apparently, like in KQ+K,,,
+            if in_check && best_eval > -MATE_SCORE_BOUND {
+                if board.piece_on(mv.to).is_none() && mv.promotion.is_none() {
+                    continue;
+                }
+            }
+
             // Per-move delta pruning (skip if capture can't possibly improve alpha)
             if can_delta {
                 let captured = board.piece_on(mv.to);


### PR DESCRIPTION
## Summary

Noticed during a game that the engine couldn't find mate in a KQ vs K endgame, and it was stuck at depth 17 with seldepth 96-100 and just showed +24. But running the same position from scratch with `position fen` found mate-9 by depth 25 with seldepth 53. The difference was a 100% full TT from the game causing QSearch check chains to explode (not entirely sure why that would be the case, but sure).

## Changes

After the first check evasion establishes a non-mate score, skip quiet evasions. This is what Stockfish does from the looks of it, and I guess it helps because when we're in check and have already searched one evasion that shows we're not getting mated, the remaining quiet moves (evasions, blocks) are unlikely to be meaningfully better - they just feed into more check chains. 

Captures and promotions are still searched, though, since those actually change the material balance.