### PR TITLE
perf: limit double extensions

### DIFF
--- a/search/src/config.rs
+++ b/search/src/config.rs
@@ -160,7 +160,7 @@ define_config!(
     (singular_depth_margin: u8, "Singular Depth Margin", UciOptionType::Spin { min: 1, max: 5 }, 3, cfg!(feature = "tuning")),
     (singular_beta_margin: i16, "Singular Beta Margin", UciOptionType::Spin { min: 1, max: 5 }, 2, cfg!(feature = "tuning")),
     (double_ext_margin: i16, "Double Extension Margin", UciOptionType::Spin { min: 10, max: 100 }, 50, cfg!(feature = "tuning")),
-    (double_ext_overshoot_penalty: i16, "Double Extension Overshoot Penalty", UciOptionType::Spin { min: 0, max: 20 }, 3, cfg!(feature = "tuning")),
+    (double_ext_overshoot_penalty: i16, "Double Extension Overshoot Penalty", UciOptionType::Spin { min: 0, max: 3 }, 2, cfg!(feature = "tuning")),
 
     (correction_history_max_value: i32, "Correction History Max Value", UciOptionType::Spin { min: 128, max: 2048 }, 1024, cfg!(feature = "tuning")),
     (correction_table_size: usize, "Correction Table Size", UciOptionType::Spin { min: 1024, max: 65536 }, 16384, cfg!(feature = "tuning")),

--- a/search/src/config.rs
+++ b/search/src/config.rs
@@ -160,6 +160,7 @@ define_config!(
     (singular_depth_margin: u8, "Singular Depth Margin", UciOptionType::Spin { min: 1, max: 5 }, 3, cfg!(feature = "tuning")),
     (singular_beta_margin: i16, "Singular Beta Margin", UciOptionType::Spin { min: 1, max: 5 }, 2, cfg!(feature = "tuning")),
     (double_ext_margin: i16, "Double Extension Margin", UciOptionType::Spin { min: 10, max: 100 }, 50, cfg!(feature = "tuning")),
+    (double_ext_overshoot_penalty: i16, "Double Extension Overshoot Penalty", UciOptionType::Spin { min: 0, max: 50 }, 15, cfg!(feature = "tuning")),
 
     (correction_history_max_value: i32, "Correction History Max Value", UciOptionType::Spin { min: 128, max: 2048 }, 1024, cfg!(feature = "tuning")),
     (correction_table_size: usize, "Correction Table Size", UciOptionType::Spin { min: 1024, max: 65536 }, 16384, cfg!(feature = "tuning")),

--- a/search/src/config.rs
+++ b/search/src/config.rs
@@ -160,7 +160,7 @@ define_config!(
     (singular_depth_margin: u8, "Singular Depth Margin", UciOptionType::Spin { min: 1, max: 5 }, 3, cfg!(feature = "tuning")),
     (singular_beta_margin: i16, "Singular Beta Margin", UciOptionType::Spin { min: 1, max: 5 }, 2, cfg!(feature = "tuning")),
     (double_ext_margin: i16, "Double Extension Margin", UciOptionType::Spin { min: 10, max: 100 }, 50, cfg!(feature = "tuning")),
-    (double_ext_overshoot_penalty: i16, "Double Extension Overshoot Penalty", UciOptionType::Spin { min: 0, max: 50 }, 15, cfg!(feature = "tuning")),
+    (double_ext_overshoot_penalty: i16, "Double Extension Overshoot Penalty", UciOptionType::Spin { min: 0, max: 20 }, 3, cfg!(feature = "tuning")),
 
     (correction_history_max_value: i32, "Correction History Max Value", UciOptionType::Spin { min: 128, max: 2048 }, 1024, cfg!(feature = "tuning")),
     (correction_table_size: usize, "Correction Table Size", UciOptionType::Spin { min: 1024, max: 65536 }, 16384, cfg!(feature = "tuning")),

--- a/search/src/searcher/mod.rs
+++ b/search/src/searcher/mod.rs
@@ -55,6 +55,9 @@ pub struct Searcher {
     /// Selective depth (max ply reached including quiescence - deepest we have gotten)
     max_ply_reached: u8,
 
+    /// Current iterative deepening depth
+    root_depth: u8,
+
     /// Tracks active search path - used for repetition, improving, etc.
     search_stack: SearchStack,
 
@@ -101,6 +104,7 @@ impl Searcher {
             game_history: AHashSet::new(),
             nodes: 0,
             max_ply_reached: 1,
+            root_depth: 0,
 
             search_stack: SearchStack::with_capacity(MAX_DEPTH),
 

--- a/search/src/searcher/search.rs
+++ b/search/src/searcher/search.rs
@@ -63,6 +63,7 @@ impl Searcher {
             }
 
             self.multi_pv.reset_excluded();
+            self.root_depth = depth;
 
             for pv_index in 0..pv_count {
                 let (pv, failures) = self.search_pv(&root, depth, pv_index);

--- a/search/src/searcher/singular.rs
+++ b/search/src/searcher/singular.rs
@@ -77,7 +77,11 @@ impl Searcher {
 
         if singular_value < singular_beta {
             // TT move is uniquely strong: extend (extra if very singular).
-            if singular_value < singular_beta.saturating_sub(self.config.double_ext_margin.value) {
+            if singular_value < singular_beta.saturating_sub(self.config.double_ext_margin.value)
+                // Limit double extensions when ply exceeds depth to prevent
+                // search explosion from repeated singular extensions (e.g. check chains).
+                && ply <= depth * 2
+            {
                 result.extension = 2;
                 return result;
             }

--- a/search/src/searcher/singular.rs
+++ b/search/src/searcher/singular.rs
@@ -77,11 +77,13 @@ impl Searcher {
 
         if singular_value < singular_beta {
             // TT move is uniquely strong: extend (extra if very singular).
-            if singular_value < singular_beta.saturating_sub(self.config.double_ext_margin.value)
-                // Limit double extensions when ply exceeds depth to prevent
-                // search explosion from repeated singular extensions (e.g. check chains).
-                && ply <= depth * 2
-            {
+            // Widen the margin when ply exceeds root depth to make double
+            // extensions progressively harder deep in the tree.
+            // Should help cases where TT hits givve check chains (KQ+K,,, etc).
+            let overshoot = ply.saturating_sub(self.root_depth) as i16;
+            let double_margin = self.config.double_ext_margin.value
+                + overshoot * self.config.double_ext_overshoot_penalty.value;
+            if singular_value < singular_beta.saturating_sub(double_margin) {
                 result.extension = 2;
                 return result;
             }

--- a/search/src/searcher/singular.rs
+++ b/search/src/searcher/singular.rs
@@ -82,7 +82,7 @@ impl Searcher {
             // Should help cases where TT hits givve check chains (KQ+K,,, etc).
             let overshoot = ply.saturating_sub(self.root_depth) as i16;
             let double_margin = self.config.double_ext_margin.value
-                + overshoot * self.config.double_ext_overshoot_penalty.value;
+                + overshoot * overshoot * self.config.double_ext_overshoot_penalty.value;
             if singular_value < singular_beta.saturating_sub(double_margin) {
                 result.extension = 2;
                 return result;


### PR DESCRIPTION
Continuation of #190 to address the (actual - likely) problem.

TLDR: the search likely over-extends singular moves in positions such as KQ+K when the TT is full, which lead to a never-ending check chain in a mate-in-9 situation in a game.

This PR reduces the horizon at which singular (double) extensions are viable by increasing the margin quadratically based on the overshoot between the root ply (iterative deepening) and the current ply (which might be extended).

Currently set this to 2, so that overshoot^2 * 2.

So if the search depth is 20 and the current ply is extended to 28, the penalty will be (28-20)^2*2, so 128, making it less likely to extend again in already extended situations.