### PR TITLE
perf: negative extensions

### DIFF
--- a/search/src/config.rs
+++ b/search/src/config.rs
@@ -158,11 +158,11 @@ define_config!(
 
     (singular_min_depth: u8, "Singular Min Depth", UciOptionType::Spin { min: 4, max: 12 }, 6, cfg!(feature = "tuning")),
     (singular_depth_margin: u8, "Singular Depth Margin", UciOptionType::Spin { min: 1, max: 5 }, 3, cfg!(feature = "tuning")),
-    (singular_beta_margin: i16, "Singular Beta Margin", UciOptionType::Spin { min: 50, max: 400 }, 140, cfg!(feature = "tuning")),
+    (singular_beta_margin: i16, "Singular Beta Margin", UciOptionType::Spin { min: 50, max: 400 }, 200, cfg!(feature = "tuning")),
     (double_ext_margin: i16, "Double Extension Margin", UciOptionType::Spin { min: 10, max: 100 }, 50, cfg!(feature = "tuning")),
     (double_ext_overshoot_penalty: i16, "Double Extension Overshoot Penalty", UciOptionType::Spin { min: 0, max: 3 }, 2, cfg!(feature = "tuning")),
-    (negative_ext_tt_high: i8, "Negative Extension TT High", UciOptionType::Spin { min: 0, max: 4 }, 2, cfg!(feature = "tuning")),
-    (negative_ext_cut_node: i8, "Negative Extension Cut Node", UciOptionType::Spin { min: 0, max: 4 }, 1, cfg!(feature = "tuning")),
+    (negative_ext_tt_high: i8, "Negative Extension TT High", UciOptionType::Spin { min: 0, max: 5 }, 2, cfg!(feature = "tuning")),
+    (negative_ext_cut_node: i8, "Negative Extension Cut Node", UciOptionType::Spin { min: 0, max: 5 }, 1, cfg!(feature = "tuning")),
 
     (correction_history_max_value: i32, "Correction History Max Value", UciOptionType::Spin { min: 128, max: 2048 }, 1024, cfg!(feature = "tuning")),
     (correction_table_size: usize, "Correction Table Size", UciOptionType::Spin { min: 1024, max: 65536 }, 16384, cfg!(feature = "tuning")),

--- a/search/src/config.rs
+++ b/search/src/config.rs
@@ -158,7 +158,7 @@ define_config!(
 
     (singular_min_depth: u8, "Singular Min Depth", UciOptionType::Spin { min: 4, max: 12 }, 6, cfg!(feature = "tuning")),
     (singular_depth_margin: u8, "Singular Depth Margin", UciOptionType::Spin { min: 1, max: 5 }, 3, cfg!(feature = "tuning")),
-    (singular_beta_margin: i16, "Singular Beta Margin", UciOptionType::Spin { min: 50, max: 400 }, 200, cfg!(feature = "tuning")),
+    (singular_beta_margin: i16, "Singular Beta Margin", UciOptionType::Spin { min: 50, max: 400 }, 280, cfg!(feature = "tuning")),
     (double_ext_margin: i16, "Double Extension Margin", UciOptionType::Spin { min: 10, max: 100 }, 50, cfg!(feature = "tuning")),
     (double_ext_overshoot_penalty: i16, "Double Extension Overshoot Penalty", UciOptionType::Spin { min: 0, max: 3 }, 2, cfg!(feature = "tuning")),
     (negative_ext_tt_high: i8, "Negative Extension TT High", UciOptionType::Spin { min: 0, max: 5 }, 2, cfg!(feature = "tuning")),

--- a/search/src/config.rs
+++ b/search/src/config.rs
@@ -158,7 +158,7 @@ define_config!(
 
     (singular_min_depth: u8, "Singular Min Depth", UciOptionType::Spin { min: 4, max: 12 }, 6, cfg!(feature = "tuning")),
     (singular_depth_margin: u8, "Singular Depth Margin", UciOptionType::Spin { min: 1, max: 5 }, 3, cfg!(feature = "tuning")),
-    (singular_beta_margin: i16, "Singular Beta Margin", UciOptionType::Spin { min: 50, max: 400 }, 200, cfg!(feature = "tuning")),
+    (singular_beta_margin: i16, "Singular Beta Margin", UciOptionType::Spin { min: 50, max: 400 }, 140, cfg!(feature = "tuning")),
     (double_ext_margin: i16, "Double Extension Margin", UciOptionType::Spin { min: 10, max: 100 }, 50, cfg!(feature = "tuning")),
     (double_ext_overshoot_penalty: i16, "Double Extension Overshoot Penalty", UciOptionType::Spin { min: 0, max: 3 }, 2, cfg!(feature = "tuning")),
     (negative_ext_tt_high: i8, "Negative Extension TT High", UciOptionType::Spin { min: 0, max: 4 }, 2, cfg!(feature = "tuning")),

--- a/search/src/config.rs
+++ b/search/src/config.rs
@@ -158,9 +158,11 @@ define_config!(
 
     (singular_min_depth: u8, "Singular Min Depth", UciOptionType::Spin { min: 4, max: 12 }, 6, cfg!(feature = "tuning")),
     (singular_depth_margin: u8, "Singular Depth Margin", UciOptionType::Spin { min: 1, max: 5 }, 3, cfg!(feature = "tuning")),
-    (singular_beta_margin: i16, "Singular Beta Margin", UciOptionType::Spin { min: 1, max: 5 }, 2, cfg!(feature = "tuning")),
+    (singular_beta_margin: i16, "Singular Beta Margin", UciOptionType::Spin { min: 50, max: 400 }, 200, cfg!(feature = "tuning")),
     (double_ext_margin: i16, "Double Extension Margin", UciOptionType::Spin { min: 10, max: 100 }, 50, cfg!(feature = "tuning")),
     (double_ext_overshoot_penalty: i16, "Double Extension Overshoot Penalty", UciOptionType::Spin { min: 0, max: 3 }, 2, cfg!(feature = "tuning")),
+    (negative_ext_tt_high: i8, "Negative Extension TT High", UciOptionType::Spin { min: 0, max: 4 }, 2, cfg!(feature = "tuning")),
+    (negative_ext_cut_node: i8, "Negative Extension Cut Node", UciOptionType::Spin { min: 0, max: 4 }, 1, cfg!(feature = "tuning")),
 
     (correction_history_max_value: i32, "Correction History Max Value", UciOptionType::Spin { min: 128, max: 2048 }, 1024, cfg!(feature = "tuning")),
     (correction_table_size: usize, "Correction Table Size", UciOptionType::Spin { min: 1024, max: 65536 }, 16384, cfg!(feature = "tuning")),

--- a/search/src/searcher/search.rs
+++ b/search/src/searcher/search.rs
@@ -579,10 +579,9 @@ impl Searcher {
             Reduction::Prune => return None,
         };
 
-        let extension = self.get_extension(node, &m, moved_piece, is_cap);
-        let extension = (extension + extra_extension).max(0) as u8;
+        let extension = self.get_extension(node, &m, moved_piece, is_cap) + extra_extension;
 
-        let mut adjusted_depth = depth.saturating_add(extension).saturating_sub(reduction);
+        let mut adjusted_depth = (depth as i16 + extension as i16 - reduction as i16).max(0) as u8;
 
         let child_bounds = if is_pv_move {
             bounds.invert()
@@ -606,7 +605,7 @@ impl Searcher {
             child.set_type(child.node_type().inverted());
 
             // Search at full depth
-            adjusted_depth = depth.saturating_add(extension);
+            adjusted_depth = (depth as i16 + extension as i16).max(0) as u8;
 
             self.search_stack
                 .push_move(&child, m, moved_piece, moved_color);

--- a/search/src/searcher/singular.rs
+++ b/search/src/searcher/singular.rs
@@ -59,9 +59,9 @@ impl Searcher {
         }
 
         let singular_depth = (depth - 1) / 2;
-        let singular_beta = tt
-            .value
-            .saturating_sub((self.config.singular_beta_margin.value * depth as i16).max(1));
+        let singular_beta = tt.value.saturating_sub(
+            (self.config.singular_beta_margin.value as i32 * depth as i32 / 100).max(1) as i16,
+        );
 
         // Reduced null-window search excluding TT move.
         self.search_stack
@@ -99,8 +99,12 @@ impl Searcher {
             return result;
         }
 
-        // TODO: Negative extensions. Infrastructure is now in place
-        // but tested neutral at STC/LTC. Revisit after tuning.
+        // Negative extensions (inspired by Stockfish).
+        if tt.value >= beta && !node.is_pv() {
+            result.extension = -self.config.negative_ext_tt_high.value;
+        } else if node.is_cut() {
+            result.extension = -self.config.negative_ext_cut_node.value;
+        }
 
         result
     }

--- a/search/src/searcher/singular.rs
+++ b/search/src/searcher/singular.rs
@@ -100,7 +100,7 @@ impl Searcher {
         }
 
         // Negative extensions (based on Stockfish).
-        // <https://www.chessprogramming.org/Extensions#Negative_Extensions>
+        // <https://www.chessprogramming.org/Extensions>
         if tt.value >= beta {
             result.extension = -self.config.negative_ext_tt_high.value;
         } else if node.is_cut() {

--- a/search/src/searcher/singular.rs
+++ b/search/src/searcher/singular.rs
@@ -99,8 +99,9 @@ impl Searcher {
             return result;
         }
 
-        // Negative extensions (inspired by Stockfish).
-        if tt.value >= beta && !node.is_pv() {
+        // Negative extensions (based on Stockfish).
+        // <https://www.chessprogramming.org/Extensions#Negative_Extensions>
+        if tt.value >= beta {
             result.extension = -self.config.negative_ext_tt_high.value;
         } else if node.is_cut() {
             result.extension = -self.config.negative_ext_cut_node.value;


### PR DESCRIPTION
## Summary

Based on Stockfish's negative extension logic: when the singular search shows that multiple moves are strong, the position is stable enough for us to reduce the TT move. A milder reduction is also applied on cut nodes, where a cutoff is expected regardless.

Also rescales `singular_beta_margin` from integer-step (`margin * depth`) to centipawn-based (`margin * depth / 100`) for finer-grained SPSA tuning.