### PR TITLE
nnue: distance-based WDL blending

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,10 +116,10 @@ make generate
 **Arguments:**
 
 - `--book`: Path to an opening book in EPD format (required).
-- `--depth`: Search depth for each move (default: 10).
+- `--depth`: Search depth for each move (default: 8).
 - `--pv-lines`: Number of PV lines to search at each decision point (default: 1).
 - `--threads`: Number of threads (default: number of logical CPUs).
-- `--nnue`: Use NNUE for evaluation instead of HCE (default: false).
+- `--syzygy-path`: Paths to Syzygy tablebase files (separated by `;` on Windows, `:` on Linux/macOS). Optional.
 
 Generated data is saved to `nnue/data/YYYY-MM-DD-HH:MM.csv`.
 
@@ -138,14 +138,15 @@ The trainer loads all CSV files from `nnue/data/` and saves the best model to `n
 
 - `--batch-size`: Batch size for training (default: 8192).
 - `--learning-rate`: Initial learning rate (default: 0.001).
-- `--epochs`: Number of epochs to train (default: 100).
+- `--epochs`: Number of epochs to train (default: 200).
 - `--workers`: Number of worker threads for data loading (default: 4).
-- `--val-ratio`: Fraction of data to use for validation (default: 0.1).
+- `--val-ratio`: Fraction of data to use for validation (default: 0.05).
 - `--test-ratio`: Fraction of data to use for testing (default: 0.01).
 - `--lr-decay`: Learning rate decay factor (default: 0.95).
-- `--patience`: Epochs without improvement before early stopping (default: 2).
+- `--patience`: Epochs without improvement before early stopping (default: 5).
 - `--shard-size-mb`: Size of each data shard in megabytes (default: 500).
-- `--wdl`: WDL blending weight, 0.0 = pure eval, 1.0 = pure WDL (default: 0.3).
+- `--wdl-start`: WDL blending weight far from game end (default: 0.2).
+- `--wdl-end`: WDL blending weight at game end (default: 0.8).
 - `--init-model`: Save a randomly initialized model and exit.
 
 ## Acknowledgements

--- a/training/src/bin/generate/game.rs
+++ b/training/src/bin/generate/game.rs
@@ -143,6 +143,9 @@ impl SelfPlayGame {
         if has_insufficient_material(&self.board) {
             return true;
         }
+        if self.board.halfmove_clock() >= 100 {
+            return true;
+        }
         // Any repetition ends game for training purposes
         let hash = self.board.hash();
         self.position_counts.get(&hash).copied().unwrap_or(0) >= 2

--- a/training/src/bin/generate/game.rs
+++ b/training/src/bin/generate/game.rs
@@ -158,13 +158,17 @@ impl SelfPlayGame {
             .collect()
     }
 
+    pub fn game_length(&self) -> u16 {
+        self.ply
+    }
+
     pub fn get_samples(&mut self) -> (Vec<Sample>, Vec<i16>) {
         let outcome = self.outcome();
         let end_ply = self.ply;
         let (samples, scores): (Vec<_>, Vec<_>) = self
             .positions
             .drain(..)
-            .map(|pos: RecordedPosition| {
+            .map(|pos| {
                 let distance_to_end = end_ply.saturating_sub(pos.ply);
                 let sample = Sample {
                     fen: pos.fen,

--- a/training/src/bin/generate/game.rs
+++ b/training/src/bin/generate/game.rs
@@ -7,6 +7,13 @@ use std::str::FromStr;
 use uci::commands::GoParams;
 use utils::{flip_eval_perspective, has_check, has_insufficient_material, has_legal_moves};
 
+struct RecordedPosition {
+    fen: String,
+    score: i16,
+    best_move: Move,
+    ply: u16,
+}
+
 /// A self-play game that generates training samples.
 ///
 /// Uses MultiPV search at decision points and teleports along chosen PV lines
@@ -15,7 +22,8 @@ pub struct SelfPlayGame {
     board: Board,
     game_id: usize,
     position_counts: HashMap<u64, usize>,
-    positions: Vec<(String, i16, Move)>, // FEN, eval, best move
+    positions: Vec<RecordedPosition>,
+    ply: u16,
     depth: u8,
 }
 
@@ -28,6 +36,7 @@ impl SelfPlayGame {
             game_id,
             position_counts: HashMap::new(),
             positions: Vec::new(),
+            ply: 0,
             depth,
         }
     }
@@ -76,8 +85,12 @@ impl SelfPlayGame {
 
     fn record_position(&mut self, eval: i16, best_move: Move) {
         let white_score = flip_eval_perspective(self.board.side_to_move(), eval);
-        self.positions
-            .push((format!("{}", self.board), white_score, best_move));
+        self.positions.push(RecordedPosition {
+            fen: format!("{}", self.board),
+            score: white_score,
+            best_move,
+            ply: self.ply,
+        });
     }
 
     fn outcome(&self) -> GameOutcome {
@@ -116,6 +129,7 @@ impl SelfPlayGame {
     /// Play a single move, updating all game state.
     fn play_move(&mut self, mv: Move) {
         self.board.play_unchecked(mv);
+        self.ply += 1;
 
         // Track position for repetition detection
         let hash = self.board.hash();
@@ -146,18 +160,21 @@ impl SelfPlayGame {
 
     pub fn get_samples(&mut self) -> (Vec<Sample>, Vec<i16>) {
         let outcome = self.outcome();
+        let end_ply = self.ply;
         let (samples, scores): (Vec<_>, Vec<_>) = self
             .positions
             .drain(..)
-            .map(|(fen, score, best_move)| {
+            .map(|pos: RecordedPosition| {
+                let distance_to_end = end_ply.saturating_sub(pos.ply);
                 let sample = Sample {
-                    fen,
-                    score,
+                    fen: pos.fen,
+                    score: pos.score,
                     game_id: self.game_id,
-                    best_move,
+                    best_move: pos.best_move,
                     outcome,
+                    distance_to_end,
                 };
-                (sample, score)
+                (sample, pos.score)
             })
             .unzip();
         (samples, scores)

--- a/training/src/bin/generate/generator.rs
+++ b/training/src/bin/generate/generator.rs
@@ -90,12 +90,16 @@ impl Generator {
             Self::spawn_progress_updater(sample_counter.clone(), histogram, stop_flag.clone());
 
         // Wait for all workers to complete
-        let samples: Vec<_> = worker_handles
+        let (samples, game_lengths): (Vec<_>, Vec<_>) = worker_handles
             .into_iter()
-            .flat_map(|h| h.join().unwrap())
-            .collect();
+            .map(|h| h.join().unwrap())
+            .unzip();
+        let samples: Vec<_> = samples.into_iter().flatten().collect();
+        let mut game_lengths: Vec<_> = game_lengths.into_iter().flatten().collect();
 
         progress_handle.join().unwrap();
+
+        Self::log_game_length_stats(&mut game_lengths);
 
         samples
     }
@@ -106,6 +110,25 @@ impl Generator {
         varmap.load(MODEL_PATH).unwrap();
         evaluator.enable_nnue();
         evaluator
+    }
+
+    fn log_game_length_stats(lengths: &mut [u16]) {
+        if lengths.is_empty() {
+            return;
+        }
+        lengths.sort_unstable();
+        let n = lengths.len();
+        let sum: u64 = lengths.iter().map(|&l| l as u64).sum();
+        let avg = sum as f64 / n as f64;
+        let median = lengths[n / 2];
+        log::info!(
+            "Game lengths ({} games): avg={:.1}, median={}, min={}, max={}",
+            n,
+            avg,
+            median,
+            lengths[0],
+            lengths[n - 1],
+        );
     }
 
     fn spawn_progress_updater(

--- a/training/src/bin/generate/samples.rs
+++ b/training/src/bin/generate/samples.rs
@@ -26,20 +26,22 @@ pub struct Sample {
     pub game_id: usize,
     pub best_move: Move,
     pub outcome: GameOutcome,
+    pub distance_to_end: u16,
 }
 
 pub fn write_samples<W: Write>(writer: &mut W, samples: &[Sample]) -> io::Result<()> {
-    writeln!(writer, "fen,score,best_move,outcome,game_id")?;
+    writeln!(writer, "fen,score,best_move,outcome,game_id,dte")?;
 
     for s in samples {
         writeln!(
             writer,
-            "{},{},{},{},{}",
+            "{},{},{},{},{},{}",
             s.fen,
             s.score.clamp(-CP_BOUND, CP_BOUND),
             s.best_move,
             s.outcome,
             s.game_id,
+            s.distance_to_end,
         )?;
     }
 

--- a/training/src/bin/generate/worker.rs
+++ b/training/src/bin/generate/worker.rs
@@ -54,8 +54,9 @@ impl SelfPlayWorker {
         }
     }
 
-    pub fn play_games(&mut self, stop_flag: Arc<AtomicBool>) -> Vec<Sample> {
+    pub fn play_games(&mut self, stop_flag: Arc<AtomicBool>) -> (Vec<Sample>, Vec<u16>) {
         let mut evaluations = Vec::new();
+        let mut game_lengths = Vec::new();
 
         while !stop_flag.load(Ordering::Relaxed) {
             let game_id = self.game_id_counter.fetch_add(1, Ordering::Relaxed);
@@ -64,13 +65,14 @@ impl SelfPlayWorker {
             let mut game = SelfPlayGame::new(game_id, opening_fen, self.depth);
             game.play(&mut self.engine);
 
+            game_lengths.push(game.game_length());
             let (samples, scores) = game.get_samples();
             self.record_statistics(&samples, scores);
 
             evaluations.extend(samples);
         }
 
-        evaluations
+        (evaluations, game_lengths)
     }
 
     fn record_statistics(&self, samples: &[Sample], scores: Vec<i16>) {

--- a/training/src/bin/train/args.rs
+++ b/training/src/bin/train/args.rs
@@ -41,11 +41,11 @@ pub struct Args {
     #[arg(long, default_value_t = 500)]
     pub shard_size_mb: usize,
 
-    /// WDL weight far from game end (trust eval).
+    /// WDL weight far from game end.
     #[arg(long, default_value_t = 0.2)]
     pub wdl_start: f64,
 
-    /// WDL weight at game end (trust outcome).
+    /// WDL weight at game end.
     #[arg(long, default_value_t = 0.8)]
     pub wdl_end: f64,
 

--- a/training/src/bin/train/args.rs
+++ b/training/src/bin/train/args.rs
@@ -41,9 +41,13 @@ pub struct Args {
     #[arg(long, default_value_t = 500)]
     pub shard_size_mb: usize,
 
-    /// WDL blending weight (0.0 = pure eval, 1.0 = pure WDL).
-    #[arg(long, default_value_t = 0.3)]
-    pub wdl: f64,
+    /// WDL weight far from game end (trust eval).
+    #[arg(long, default_value_t = 0.2)]
+    pub wdl_start: f64,
+
+    /// WDL weight at game end (trust outcome).
+    #[arg(long, default_value_t = 0.8)]
+    pub wdl_end: f64,
 
     /// Save a randomly initialized model and exit.
     #[arg(long)]

--- a/training/src/bin/train/dataset/loader.rs
+++ b/training/src/bin/train/dataset/loader.rs
@@ -13,6 +13,7 @@ pub struct Batch {
     pub scores: Vec<f32>,
     pub outcomes: Vec<f32>,
     pub buckets: Vec<usize>,
+    pub distance_to_end: Vec<u16>,
 }
 
 /// Multi-threaded data loader that reads samples from shards.
@@ -72,6 +73,7 @@ impl DataLoader {
         let mut scores = Vec::with_capacity(batch_size);
         let mut outcomes = Vec::with_capacity(batch_size);
         let mut buckets = Vec::with_capacity(batch_size);
+        let mut distance_to_end = Vec::with_capacity(batch_size);
 
         for _ in 0..batch_size {
             if shutdown.load(Ordering::Relaxed) {
@@ -85,6 +87,7 @@ impl DataLoader {
                         scores.push(encoded.score);
                         outcomes.push(encoded.outcome);
                         buckets.push(encoded.bucket);
+                        distance_to_end.push(encoded.distance_to_end);
                     }
                 }
                 None => break,
@@ -96,6 +99,7 @@ impl DataLoader {
             scores,
             outcomes,
             buckets,
+            distance_to_end,
         }
     }
 }

--- a/training/src/bin/train/dataset/shard.rs
+++ b/training/src/bin/train/dataset/shard.rs
@@ -14,6 +14,7 @@ pub struct Sample {
     pub fen: String,
     pub score: i16,
     pub outcome: f32,
+    pub distance_to_end: u16,
 }
 
 pub struct EncodedSample {
@@ -21,6 +22,7 @@ pub struct EncodedSample {
     pub score: f32,
     pub outcome: f32,
     pub bucket: usize,
+    pub distance_to_end: u16,
 }
 
 impl Sample {
@@ -45,6 +47,7 @@ impl Sample {
             outcome: self.outcome,
             bucket,
             features,
+            distance_to_end: self.distance_to_end,
         })
     }
 }
@@ -101,9 +104,12 @@ fn parse_line(line: &str) -> Option<Sample> {
         _ => return None,
     };
 
+    let distance_to_end: u16 = parts.next()?.parse().ok()?;
+
     Some(Sample {
         fen,
         score,
         outcome,
+        distance_to_end,
     })
 }

--- a/training/src/bin/train/dataset/shard_builder.rs
+++ b/training/src/bin/train/dataset/shard_builder.rs
@@ -82,7 +82,7 @@ impl ShardWriter {
             let path = dir.join(format!("shard_{}.csv", i));
             let file = File::create(&path)?;
             let mut writer = BufWriter::new(file);
-            writeln!(writer, "fen,score,outcome")?;
+            writeln!(writer, "fen,score,outcome,dte")?;
             writers.push(Mutex::new(writer));
         }
 
@@ -92,10 +92,10 @@ impl ShardWriter {
         })
     }
 
-    fn write(&self, fen: &str, score: i16, outcome: &str) {
+    fn write(&self, fen: &str, score: i16, outcome: &str, distance_to_end: u16) {
         let idx = self.next_idx.fetch_add(1, Ordering::Relaxed) % self.writers.len();
         let mut writer = self.writers[idx].lock().unwrap();
-        if let Err(e) = writeln!(writer, "{},{},{}", fen, score, outcome) {
+        if let Err(e) = writeln!(writer, "{},{},{},{}", fen, score, outcome, distance_to_end) {
             log::error!("Failed to write to shard: {}", e);
         }
     }
@@ -304,7 +304,7 @@ fn process_file(
         let line_len = line.len() as u64;
         let trimmed = line.trim();
 
-        if let Some((fen, score, outcome, game_id)) = parse_csv_line(trimmed) {
+        if let Some((fen, score, outcome, game_id, distance_to_end)) = parse_csv_line(trimmed) {
             let split = *game_assignments.entry(game_id).or_insert_with(|| {
                 stats.register_game();
                 pick_split(&mut rng, val_ratio, test_ratio)
@@ -313,9 +313,9 @@ fn process_file(
             stats.register_sample(fen, outcome, split);
 
             match split {
-                Split::Train => train_writer.write(fen, score, outcome),
-                Split::Val => val_writer.write(fen, score, outcome),
-                Split::Test => test_writer.write(fen, score, outcome),
+                Split::Train => train_writer.write(fen, score, outcome, distance_to_end),
+                Split::Val => val_writer.write(fen, score, outcome, distance_to_end),
+                Split::Test => test_writer.write(fen, score, outcome, distance_to_end),
             }
 
             samples_since_update += 1;
@@ -336,14 +336,15 @@ fn process_file(
     stats
 }
 
-fn parse_csv_line(line: &str) -> Option<(&str, i16, &str, u32)> {
+fn parse_csv_line(line: &str) -> Option<(&str, i16, &str, u32, u16)> {
     let mut parts = line.split(',');
     let fen = parts.next()?;
     let score: i16 = parts.next()?.parse().ok()?;
     let _best_move = parts.next()?;
     let outcome = parts.next()?;
     let game_id: u32 = parts.next()?.parse().ok()?;
-    Some((fen, score, outcome, game_id))
+    let distance_to_end: u16 = parts.next()?.parse().ok()?;
+    Some((fen, score, outcome, game_id, distance_to_end))
 }
 
 fn pick_split<R: rand::Rng>(rng: &mut R, val_ratio: f64, test_ratio: f64) -> Split {

--- a/training/src/bin/train/training/evaluation.rs
+++ b/training/src/bin/train/training/evaluation.rs
@@ -4,13 +4,14 @@ use nnue::network::Network;
 use std::error::Error;
 
 use crate::dataset::DataLoader;
-use crate::utils::loss::wdl_eval_loss;
+use crate::utils::loss::{wdl_eval_loss, wdl_weights};
 
 pub fn evaluate(
     network: &Network,
     loader: DataLoader,
     device: &Device,
-    wdl: f64,
+    wdl_start: f64,
+    wdl_end: f64,
 ) -> Result<f32, Box<dyn Error>> {
     let mut total_loss = 0.0;
     let mut batches = 0;
@@ -24,9 +25,10 @@ pub fn evaluate(
         let x = Tensor::from_vec(batch.features, (batch_len, NUM_FEATURES), device)?;
         let y_eval = Tensor::from_vec(batch.scores, (batch_len, 1), device)?;
         let y_outcome = Tensor::from_vec(batch.outcomes, (batch_len, 1), device)?;
+        let w = wdl_weights(&batch.distance_to_end, wdl_start, wdl_end, device)?;
 
         let preds = network.forward(&x, &batch.buckets)?;
-        let loss = wdl_eval_loss(&preds, &y_eval, &y_outcome, wdl)?;
+        let loss = wdl_eval_loss(&preds, &y_eval, &y_outcome, &w)?;
 
         total_loss += loss.to_vec0::<f32>()?;
         batches += 1;

--- a/training/src/bin/train/training/trainer.rs
+++ b/training/src/bin/train/training/trainer.rs
@@ -13,7 +13,7 @@ use crate::training::evaluation::evaluate;
 use crate::training::metrics::MetricsTracker;
 use crate::training::progress::TrainingProgressBar;
 use crate::utils::device::get_device;
-use crate::utils::loss::wdl_eval_loss;
+use crate::utils::loss::{wdl_eval_loss, wdl_weights};
 
 /// Number of shards to keep loaded for training.
 const TRAIN_SHARDS: usize = 10;
@@ -31,14 +31,14 @@ pub struct Trainer {
     epochs: usize,
     lr_decay: f64,
     patience: u64,
-    wdl: f64,
+    wdl_start: f64,
+    wdl_end: f64,
     model_path: String,
 }
 
 impl Trainer {
     pub fn new(args: &Args, model_path: &str) -> Result<Self, Box<dyn Error>> {
         let device = get_device()?;
-        let wdl = args.wdl.clamp(0.0, 1.0);
 
         let varmap = VarMap::new();
         let vs = VarBuilder::from_varmap(&varmap, DType::F32, &device);
@@ -61,7 +61,8 @@ impl Trainer {
             epochs: args.epochs,
             lr_decay: args.lr_decay,
             patience: args.patience,
-            wdl,
+            wdl_start: args.wdl_start.clamp(0.0, 1.0),
+            wdl_end: args.wdl_end.clamp(0.0, 1.0),
             model_path: model_path.to_string(),
         })
     }
@@ -73,9 +74,9 @@ impl Trainer {
     ) -> Result<(), Box<dyn Error>> {
         log::info!("Using device: {:?}", self.device);
         log::info!(
-            "WDL blending: {:.0}% WDL / {:.0}% eval",
-            self.wdl * 100.0,
-            (1.0 - self.wdl) * 100.0
+            "WDL blending: {:.0}% at start, {:.0}% at end",
+            self.wdl_start * 100.0,
+            self.wdl_end * 100.0
         );
 
         let mut metrics = MetricsTracker::new(self.patience);
@@ -141,9 +142,10 @@ impl Trainer {
             let x = Tensor::from_vec(batch.features, (batch_len, NUM_FEATURES), &self.device)?;
             let y_eval = Tensor::from_vec(batch.scores, (batch_len, 1), &self.device)?;
             let y_outcome = Tensor::from_vec(batch.outcomes, (batch_len, 1), &self.device)?;
+            let w = wdl_weights(&batch.distance_to_end, self.wdl_start, self.wdl_end, &self.device)?;
 
             let preds = self.network.forward(&x, &batch.buckets)?;
-            let loss = wdl_eval_loss(&preds, &y_eval, &y_outcome, self.wdl)?;
+            let loss = wdl_eval_loss(&preds, &y_eval, &y_outcome, &w)?;
 
             self.optimizer.backward_step(&loss)?;
 
@@ -162,7 +164,13 @@ impl Trainer {
             self.workers,
             Arc::clone(shutdown),
         );
-        let val_loss = evaluate(&self.network, val_loader, &self.device, self.wdl)?;
+        let val_loss = evaluate(
+            &self.network,
+            val_loader,
+            &self.device,
+            self.wdl_start,
+            self.wdl_end,
+        )?;
 
         progress.finish(val_loss, train_loss);
 
@@ -191,7 +199,13 @@ impl Trainer {
             self.workers,
             Arc::clone(shutdown),
         );
-        let test_loss = evaluate(&self.network, test_loader, &self.device, self.wdl)?;
+        let test_loss = evaluate(
+            &self.network,
+            test_loader,
+            &self.device,
+            self.wdl_start,
+            self.wdl_end,
+        )?;
         log::info!("Test Loss: {:.6}", test_loss);
 
         Ok(test_loss)

--- a/training/src/bin/train/training/trainer.rs
+++ b/training/src/bin/train/training/trainer.rs
@@ -142,7 +142,12 @@ impl Trainer {
             let x = Tensor::from_vec(batch.features, (batch_len, NUM_FEATURES), &self.device)?;
             let y_eval = Tensor::from_vec(batch.scores, (batch_len, 1), &self.device)?;
             let y_outcome = Tensor::from_vec(batch.outcomes, (batch_len, 1), &self.device)?;
-            let w = wdl_weights(&batch.distance_to_end, self.wdl_start, self.wdl_end, &self.device)?;
+            let w = wdl_weights(
+                &batch.distance_to_end,
+                self.wdl_start,
+                self.wdl_end,
+                &self.device,
+            )?;
 
             let preds = self.network.forward(&x, &batch.buckets)?;
             let loss = wdl_eval_loss(&preds, &y_eval, &y_outcome, &w)?;

--- a/training/src/bin/train/utils/loss.rs
+++ b/training/src/bin/train/utils/loss.rs
@@ -1,21 +1,38 @@
-use candle_core::{Result, Tensor};
+use candle_core::{Device, Result, Tensor};
 use candle_nn::loss::mse;
 use candle_nn::ops::sigmoid;
 
+const WDL_DECAY: f64 = 0.05;
+
+/// Per-sample WDL weight via exponential decay on distance-to-end.
+///
+/// w = start + (end - start) * e^(-k * d), k = 0.05 (~14-ply half-life).
+pub fn wdl_weights(distance_to_end: &[u16], start: f64, end: f64, device: &Device) -> Result<Tensor> {
+    let range = end - start;
+    let weights: Vec<f32> = distance_to_end
+        .iter()
+        .map(|&d| (start + range * (-WDL_DECAY * d as f64).exp()) as f32)
+        .collect();
+    Tensor::from_vec(weights, (distance_to_end.len(), 1), device)
+}
+
 /// Sigmoid MSE loss blending eval and game outcome in win-probability space.
 ///
-/// target = wdl * outcome + (1 - wdl) * sigmoid(eval)
+/// target = w * outcome + (1 - w) * sigmoid(eval)
 /// loss   = mean((sigmoid(output) - target)²)
+///
+/// `wdl_weights` is a per-sample tensor of shape (batch, 1).
 pub fn wdl_eval_loss(
     net_output: &Tensor,
     target_eval: &Tensor,
     target_outcome: &Tensor,
-    wdl: f64,
+    wdl_weights: &Tensor,
 ) -> Result<Tensor> {
     let sigmoid_output = sigmoid(net_output)?;
     let sigmoid_eval = sigmoid(target_eval)?;
 
-    let target = ((target_outcome * wdl)? + (sigmoid_eval * (1.0 - wdl))?)?;
+    let eval_weight = (1.0 - wdl_weights)?;
+    let target = ((target_outcome * wdl_weights)? + (sigmoid_eval * eval_weight)?)?;
 
     mse(&sigmoid_output, &target)
 }

--- a/training/src/bin/train/utils/loss.rs
+++ b/training/src/bin/train/utils/loss.rs
@@ -5,9 +5,12 @@ use candle_nn::ops::sigmoid;
 const WDL_DECAY: f64 = 0.05;
 
 /// Per-sample WDL weight via exponential decay on distance-to-end.
-///
-/// w = start + (end - start) * e^(-k * d), k = 0.05 (~14-ply half-life).
-pub fn wdl_weights(distance_to_end: &[u16], start: f64, end: f64, device: &Device) -> Result<Tensor> {
+pub fn wdl_weights(
+    distance_to_end: &[u16],
+    start: f64,
+    end: f64,
+    device: &Device,
+) -> Result<Tensor> {
     let range = end - start;
     let weights: Vec<f32> = distance_to_end
         .iter()


### PR DESCRIPTION
**WIP**: proof of concept, pending retest after endgame tablebases are implemented.

## Summary

Replaces the fixed WDL blending weight with a per-sample weight that varies based on distance-to-end (dte). Positions near the game end trust the outcome more, positions far from the end trust the eval more.

`w(d) = wdl_start + (wdl_end - wdl_start) * e^(-0.05 * d)`

<img width="2005" height="668" alt="image" src="https://github.com/user-attachments/assets/2a2666e4-9a0b-422d-bd1f-4aac8bea07d8" />

The WDL weight decays exponentially from `wdl_end` (100%) at the game end toward `wdl_start` (10%) for positions far from the end, with a half-life of ~14 plies.

The old `--wdl` flag is replaced by `--wdl_start` (default 0.2) and `--wdl_end` (default 0.8). Setting both to the same value recovers the old fixed behavior.

### Changes

- **Data generation**: Track ply count per game, compute `distance_to_end` per sample, include `dte` column in CSV output
- **Training loss**: Per-sample WDL weight tensor via exponential decay instead of a scalar
- **CLI**: `--wdl_start` and `--wdl_end` replace `--wdl`
- **Self-play**: Enforce 50-move rule in game termination
- **Stats**: Log game length distribution (avg/median/min/max) after generation

### Results

SPRT [0, 10] on 59M samples, 10%/100% dynamic vs 10% fixed:

```
--------------------------------------------------
Results of grail-wdl0.1-1 vs grail-wdl0.1 (10+0.1, 1t, 256MB, UHO_Lichess_4852_v1.epd):
Elo: 6.67 +/- 5.38, nElo: 9.86 +/- 7.94
LOS: 99.25 %, DrawRatio: 43.63 %, PairsRatio: 1.11
Games: 7348, Wins: 2467, Losses: 2326, Draws: 2555, Points: 3744.5 (50.96 %)
Ptnml(0-2): [199, 783, 1603, 856, 233], WL/DD Ratio: 2.50
LLR: 2.95 (100.3%) (-2.94, 2.94) [0.00, 10.00]
--------------------------------------------------
SPRT ([0.00, 10.00]) completed - H1 was accepted
```