### PR TITLE
feat: add Syzygy endgame tablebase probing via pyrrhic-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1346,6 +1346,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40e24eee682d89fb193496edf918a7f407d30175b2e785fe057e4392dfd182e0"
 
 [[package]]
+name = "pyrrhic-rs"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3910f053bb86e0d75fb0e61b47d82e456a15c548fb4d8a8da9d9d1a34a4e299"
+dependencies = [
+ "libc",
+ "memmap2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1492,6 +1502,7 @@ dependencies = [
  "cozy-chess",
  "log",
  "nnue",
+ "pyrrhic-rs",
  "rand",
  "uci",
  "utils",
@@ -1753,6 +1764,7 @@ dependencies = [
  "log",
  "nnue",
  "num_cpus",
+ "pyrrhic-rs",
  "rand",
  "rayon",
  "search",

--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ Once added to your GUI, you can configure the engine via the UCI options:
 - **Hash**: Size of the transposition table in MB (Default: 256).
 - **Threads**: Number of search threads (Default: 1).
 - **MultiPV**: Number of principal variations to search (Default: 1).
-- **NNUE**: Toggle between Neural Network (NNUE) and Hand-Crafted (HCE) evaluation (Default: true).
 - **Move Overhead**: Time buffer in milliseconds to account for communication lag (Default: 10).
+- **SyzygyPath**: Paths to Syzygy tablebase files (separated by `;` on Windows, `:` on Linux/macOS).
+- **SyzygyProbeDepth**: Minimum depth to probe tablebases (Default: 1).
 
 The engine supports standard time controls (increment, sudden death, moves to go) and analysis modes (fixed depth, infinite).
 

--- a/search/Cargo.toml
+++ b/search/Cargo.toml
@@ -20,6 +20,7 @@ cozy-chess = { workspace = true }
 ahash = { workspace = true }
 log = { workspace = true }
 rand = { workspace = true }
+pyrrhic-rs = "0.2"
 
 [lib]
 name = "search"

--- a/search/src/config.rs
+++ b/search/src/config.rs
@@ -78,6 +78,8 @@ define_config!(
     (threads: usize, "Threads", UciOptionType::Spin { min: 1, max: 256 }, 1, true),
     (move_overhead: i32, "Move Overhead", UciOptionType::Spin { min: 0, max: 5000 }, 10, true),
     (multi_pv: u8, "MultiPV", UciOptionType::Spin { min: 1, max: 64 }, 1, true),
+    (syzygy_path: String, "SyzygyPath", UciOptionType::String, String::new(), true),
+    (syzygy_probe_depth: u8, "SyzygyProbeDepth", UciOptionType::Spin { min: 1, max: 100 }, 1, true),
 
     // Tuning options
     (aspiration_window_size: i16, "Aspiration Window Size", UciOptionType::Spin { min: 10, max: 100 }, 40, cfg!(feature = "tuning")),

--- a/search/src/engine.rs
+++ b/search/src/engine.rs
@@ -5,10 +5,13 @@ use ahash::AHashSet;
 use cozy_chess::Board;
 use uci::UciOutput;
 
+use pyrrhic_rs::TableBases;
+
 use crate::{
     EngineConfig,
     result::SearchResult,
     searcher::{Searcher, SharedSearcherState},
+    tablebase::CozyAdapter,
     transposition::TranspositionTable,
 };
 
@@ -53,6 +56,14 @@ impl Engine {
             self.shared.correction().configure(config);
         }
 
+        if init || old_config.syzygy_path.value != config.syzygy_path.value {
+            if config.syzygy_path.value.is_empty() {
+                self.shared.clear_tablebases();
+            } else {
+                self.shared.init_tablebases(&config.syzygy_path.value);
+            }
+        }
+
         let new_num_threads = config.threads.value;
         while self.searchers.len() < new_num_threads {
             let thread_id = self.searchers.len();
@@ -86,6 +97,10 @@ impl Engine {
 
     pub fn board(&self) -> &Board {
         &self.board
+    }
+
+    pub fn set_tablebases(&self, tb: TableBases<CozyAdapter>) {
+        self.shared.set_tablebases(tb);
     }
 
     pub fn stop(&self) {

--- a/search/src/lib.rs
+++ b/search/src/lib.rs
@@ -11,6 +11,7 @@ mod result;
 mod scores;
 pub(crate) mod searcher;
 mod stack;
+pub mod tablebase;
 mod time_control;
 mod transposition;
 mod utils;
@@ -22,5 +23,6 @@ pub use config::EngineConfig;
 pub use engine::Engine;
 pub use pv::PvLine;
 pub use result::SearchResult;
+pub use tablebase::CozyAdapter;
 
 pub use ::utils::{Node, NodeType};

--- a/search/src/searcher/eval.rs
+++ b/search/src/searcher/eval.rs
@@ -1,5 +1,7 @@
 use utils::{Node, cap_eval_by_material, flip_eval_perspective};
 
+use crate::tablebase;
+
 use super::Searcher;
 
 impl Searcher {
@@ -28,5 +30,17 @@ impl Searcher {
     /// Check if the position is a forced draw (fifty-move rule or repetition).
     pub(super) fn is_forced_draw(&self, node: &Node) -> bool {
         node.is_fifty_move_draw() || self.search_stack.is_repetition(&self.game_history)
+    }
+
+    /// Probe Syzygy tablebases for an exact WDL score. Returns None if
+    /// tablebases aren't loaded, the position has too many pieces, or depth
+    /// is below the configured probe threshold.
+    pub(super) fn probe_tb_wdl(&self, node: &Node, depth: u8) -> Option<i16> {
+        let tb = self.shared.tb()?;
+        if depth < self.config.syzygy_probe_depth.value {
+            return None;
+        }
+        let wdl = tablebase::probe_wdl(tb, node.board())?;
+        Some(tablebase::wdl_to_score(wdl, self.draw_value()))
     }
 }

--- a/search/src/searcher/search.rs
+++ b/search/src/searcher/search.rs
@@ -226,6 +226,12 @@ impl Searcher {
             return self.draw_value();
         }
 
+        if ply > 0 {
+            if let Some(score) = self.probe_tb_wdl(node, depth) {
+                return score;
+            }
+        }
+
         // As deep as we can go, so return static eval
         if ply as usize >= MAX_DEPTH {
             return self.static_eval(node);

--- a/search/src/searcher/shared_state.rs
+++ b/search/src/searcher/shared_state.rs
@@ -4,8 +4,11 @@ use std::sync::{
     atomic::{AtomicBool, AtomicU64, Ordering},
 };
 
+use pyrrhic_rs::TableBases;
+
 use crate::EngineConfig;
 use crate::history::CorrectionHistory;
+use crate::tablebase::CozyAdapter;
 use crate::transposition::TranspositionTable;
 
 /// Shared mutable state for searchers.
@@ -17,6 +20,7 @@ use crate::transposition::TranspositionTable;
 pub struct SharedSearcherState {
     tt: UnsafeCell<TranspositionTable>,
     correction: UnsafeCell<CorrectionHistory>,
+    tb: UnsafeCell<Option<TableBases<CozyAdapter>>>,
     stop: Arc<AtomicBool>,
     total_nodes: AtomicU64,
 }
@@ -41,6 +45,7 @@ impl SharedSearcherState {
         Self {
             tt: UnsafeCell::new(tt),
             correction: UnsafeCell::new(correction),
+            tb: UnsafeCell::new(None),
             stop,
             total_nodes: AtomicU64::new(0),
         }
@@ -74,5 +79,32 @@ impl SharedSearcherState {
 
     pub fn reset_nodes(&self) {
         self.total_nodes.store(0, Ordering::Relaxed);
+    }
+
+    /// Load from path (UCI `setoption`). Only call when no search is running.
+    pub fn init_tablebases(&self, path: &str) {
+        match TableBases::<CozyAdapter>::new(path) {
+            Ok(tb) => {
+                log::info!("Syzygy tablebases loaded: up to {} pieces", tb.max_pieces());
+                unsafe { *self.tb.get() = Some(tb) }
+            }
+            Err(e) => {
+                log::warn!("Failed to load Syzygy tablebases: {:?}", e);
+                unsafe { *self.tb.get() = None }
+            }
+        }
+    }
+
+    pub fn clear_tablebases(&self) {
+        unsafe { *self.tb.get() = None }
+    }
+
+    /// Inject an already-loaded handle (data gen workers share one instance via clone).
+    pub fn set_tablebases(&self, tb: TableBases<CozyAdapter>) {
+        unsafe { *self.tb.get() = Some(tb) }
+    }
+
+    pub fn tb(&self) -> Option<&TableBases<CozyAdapter>> {
+        unsafe { (*self.tb.get()).as_ref() }
     }
 }

--- a/search/src/searcher/shared_state.rs
+++ b/search/src/searcher/shared_state.rs
@@ -82,7 +82,9 @@ impl SharedSearcherState {
     }
 
     /// Load from path (UCI `setoption`). Only call when no search is running.
+    /// Accepts both `;` and `:` as path separators for Windows compatibility.
     pub fn init_tablebases(&self, path: &str) {
+        let path = path.replace(';', ":");
         match TableBases::<CozyAdapter>::new(path) {
             Ok(tb) => {
                 log::info!("Syzygy tablebases loaded: up to {} pieces", tb.max_pieces());

--- a/search/src/tablebase.rs
+++ b/search/src/tablebase.rs
@@ -1,0 +1,95 @@
+use cozy_chess::{
+    BitBoard, Board, Color, Piece, Square, get_bishop_moves, get_king_moves, get_knight_moves,
+    get_pawn_attacks, get_rook_moves,
+};
+use pyrrhic_rs::{EngineAdapter, TableBases, WdlProbeResult};
+use utils::en_passant_square;
+
+use crate::scores::MATE_VALUE;
+use crate::MAX_DEPTH;
+
+/// Just below MATE_VALUE - MAX_DEPTH so TB wins don't trigger "score mate X" in UCI output,
+/// but above MATE_SCORE_BOUND so the TT's ply normalization handles them correctly.
+pub const TB_WIN: i16 = MATE_VALUE - MAX_DEPTH as i16 - 1;
+
+/// Adapter wiring cozy_chess attack generation into pyrrhic-rs.
+/// Based on the cozy_chess example from https://docs.rs/pyrrhic-rs/latest/pyrrhic_rs/
+#[derive(Clone)]
+pub struct CozyAdapter;
+
+impl EngineAdapter for CozyAdapter {
+    fn pawn_attacks(color: pyrrhic_rs::Color, sq: u64) -> u64 {
+        get_pawn_attacks(
+            Square::index(sq as usize),
+            if color == pyrrhic_rs::Color::Black {
+                Color::Black
+            } else {
+                Color::White
+            },
+        )
+        .0
+    }
+
+    fn knight_attacks(sq: u64) -> u64 {
+        get_knight_moves(Square::index(sq as usize)).0
+    }
+
+    fn bishop_attacks(sq: u64, occ: u64) -> u64 {
+        get_bishop_moves(Square::index(sq as usize), BitBoard(occ)).0
+    }
+
+    fn rook_attacks(sq: u64, occ: u64) -> u64 {
+        get_rook_moves(Square::index(sq as usize), BitBoard(occ)).0
+    }
+
+    fn king_attacks(sq: u64) -> u64 {
+        get_king_moves(Square::index(sq as usize)).0
+    }
+
+    fn queen_attacks(sq: u64, occ: u64) -> u64 {
+        (get_bishop_moves(Square::index(sq as usize), BitBoard(occ))
+            | get_rook_moves(Square::index(sq as usize), BitBoard(occ)))
+        .0
+    }
+}
+
+pub fn probe_wdl(tb: &TableBases<CozyAdapter>, board: &Board) -> Option<WdlProbeResult> {
+    if board.occupied().len() > tb.max_pieces() {
+        return None;
+    }
+    let w = board.castle_rights(Color::White);
+    let b = board.castle_rights(Color::Black);
+    if w.short.is_some() || w.long.is_some() || b.short.is_some() || b.long.is_some() {
+        return None;
+    }
+
+    let white = board.colors(Color::White).0;
+    let black = board.colors(Color::Black).0;
+    let kings = board.pieces(Piece::King).0;
+    let queens = board.pieces(Piece::Queen).0;
+    let rooks = board.pieces(Piece::Rook).0;
+    let bishops = board.pieces(Piece::Bishop).0;
+    let knights = board.pieces(Piece::Knight).0;
+    let pawns = board.pieces(Piece::Pawn).0;
+
+    let ep = en_passant_square(board).map(|sq| sq as u32).unwrap_or(0);
+
+    let turn = board.side_to_move() == Color::White;
+
+    tb.probe_wdl(
+        white, black, kings, queens, rooks, bishops, knights, pawns, ep, turn,
+    )
+    .ok()
+}
+
+/// Map WDL to a search score. TB_WIN sits in the mate-score range so the TT's
+/// ply normalization automatically makes the engine prefer shorter winning paths.
+pub fn wdl_to_score(wdl: WdlProbeResult, draw_value: i16) -> i16 {
+    match wdl {
+        WdlProbeResult::Win => TB_WIN,
+        WdlProbeResult::Loss => -TB_WIN,
+        WdlProbeResult::Draw | WdlProbeResult::CursedWin | WdlProbeResult::BlessedLoss => {
+            draw_value
+        }
+    }
+}

--- a/search/src/tablebase.rs
+++ b/search/src/tablebase.rs
@@ -5,8 +5,8 @@ use cozy_chess::{
 use pyrrhic_rs::{EngineAdapter, TableBases, WdlProbeResult};
 use utils::en_passant_square;
 
-use crate::scores::MATE_VALUE;
 use crate::MAX_DEPTH;
+use crate::scores::MATE_VALUE;
 
 /// Just below MATE_VALUE - MAX_DEPTH so TB wins don't trigger "score mate X" in UCI output,
 /// but above MATE_SCORE_BOUND so the TT's ply normalization handles them correctly.

--- a/training/Cargo.toml
+++ b/training/Cargo.toml
@@ -28,6 +28,7 @@ candle-nn = { workspace = true }
 indicatif = { workspace = true }
 tempfile = { workspace = true }
 hyperloglogplus = { workspace = true }
+pyrrhic-rs = "0.2"
 
 [features]
 default = []

--- a/training/src/bin/generate/args.rs
+++ b/training/src/bin/generate/args.rs
@@ -20,4 +20,8 @@ pub struct Args {
     /// Number of PV lines to search at each decision point.
     #[arg(long, default_value_t = 1)]
     pub pv_lines: u8,
+
+    /// Colon-separated paths to Syzygy tablebase files.
+    #[arg(long)]
+    pub syzygy_path: Option<String>,
 }

--- a/training/src/bin/generate/game.rs
+++ b/training/src/bin/generate/game.rs
@@ -1,7 +1,8 @@
 use crate::samples::{GameOutcome, Sample};
 use cozy_chess::{Board, Color, Move};
+use pyrrhic_rs::{TableBases, WdlProbeResult};
 use rand::Rng;
-use search::{Engine, PvLine, SearchResult};
+use search::{CozyAdapter, Engine, PvLine, SearchResult};
 use std::collections::HashMap;
 use std::str::FromStr;
 use uci::commands::GoParams;
@@ -17,10 +18,16 @@ pub struct SelfPlayGame {
     position_counts: HashMap<u64, usize>,
     positions: Vec<(String, i16, Move)>, // FEN, eval, best move
     depth: u8,
+    tablebases: Option<TableBases<CozyAdapter>>,
 }
 
 impl SelfPlayGame {
-    pub fn new(game_id: usize, opening_fen: &str, depth: u8) -> Self {
+    pub fn new(
+        game_id: usize,
+        opening_fen: &str,
+        depth: u8,
+        tablebases: Option<TableBases<CozyAdapter>>,
+    ) -> Self {
         let board = Board::from_str(opening_fen).unwrap();
 
         Self {
@@ -29,6 +36,7 @@ impl SelfPlayGame {
             position_counts: HashMap::new(),
             positions: Vec::new(),
             depth,
+            tablebases,
         }
     }
 
@@ -131,7 +139,19 @@ impl SelfPlayGame {
         }
         // Any repetition ends game for training purposes
         let hash = self.board.hash();
-        self.position_counts.get(&hash).copied().unwrap_or(0) >= 2
+        if self.position_counts.get(&hash).copied().unwrap_or(0) >= 2 {
+            return true;
+        }
+        // Adjudicate theoretical draws via tablebases (wins/losses play on naturally)
+        if let Some(tb) = self.tablebases.as_ref() {
+            if let Some(
+                WdlProbeResult::Draw | WdlProbeResult::CursedWin | WdlProbeResult::BlessedLoss,
+            ) = search::tablebase::probe_wdl(tb, &self.board)
+            {
+                return true;
+            }
+        }
+        false
     }
 
     /// Get position history for repetition detection during search.

--- a/training/src/bin/generate/generator.rs
+++ b/training/src/bin/generate/generator.rs
@@ -43,6 +43,7 @@ impl Generator {
 
         let tablebases = match syzygy_path {
             Some(path) => {
+                let path = path.replace(';', ":");
                 let tb = TableBases::<CozyAdapter>::new(&path)
                     .map_err(|e| format!("Failed to load Syzygy tablebases: {:?}", e))?;
                 log::info!("Syzygy tablebases loaded: up to {} pieces", tb.max_pieces());

--- a/training/src/bin/generate/generator.rs
+++ b/training/src/bin/generate/generator.rs
@@ -5,6 +5,8 @@ use crate::worker::SelfPlayWorker;
 use candle_core::Device;
 use candle_nn::VarMap;
 use indicatif::MultiProgress;
+use pyrrhic_rs::TableBases;
+use search::CozyAdapter;
 use std::error::Error;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -19,6 +21,7 @@ pub struct Generator {
     threads: usize,
     pv_lines: u8,
     opening_book: Arc<Book>,
+    tablebases: Option<TableBases<CozyAdapter>>,
 }
 
 impl Generator {
@@ -26,6 +29,7 @@ impl Generator {
         threads: usize,
         pv_lines: u8,
         opening_book_path: String,
+        syzygy_path: Option<String>,
     ) -> Result<Self, Box<dyn Error>> {
         let opening_book = Arc::new(Book::load(&opening_book_path)?);
 
@@ -37,10 +41,21 @@ impl Generator {
             .into());
         }
 
+        let tablebases = match syzygy_path {
+            Some(path) => {
+                let tb = TableBases::<CozyAdapter>::new(&path)
+                    .map_err(|e| format!("Failed to load Syzygy tablebases: {:?}", e))?;
+                log::info!("Syzygy tablebases loaded: up to {} pieces", tb.max_pieces());
+                Some(tb)
+            }
+            None => None,
+        };
+
         Ok(Self {
             threads,
             pv_lines,
             opening_book,
+            tablebases,
         })
     }
 
@@ -68,6 +83,7 @@ impl Generator {
                 let opening_book = Arc::clone(&self.opening_book);
                 let stop_flag = Arc::clone(&stop_flag);
                 let histogram_handle = histogram.clone_handle();
+                let tb = self.tablebases.clone();
 
                 std::thread::spawn(move || {
                     let mut worker = SelfPlayWorker::new(
@@ -79,6 +95,7 @@ impl Generator {
                         Self::load_nnue,
                         opening_book,
                         histogram_handle,
+                        tb,
                     );
                     worker.play_games(stop_flag)
                 })

--- a/training/src/bin/generate/main.rs
+++ b/training/src/bin/generate/main.rs
@@ -35,7 +35,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     })?;
 
     let threads = args.threads.unwrap_or_else(num_cpus::get);
-    let generator = Generator::new(threads, args.pv_lines, args.book)?;
+    let generator = Generator::new(threads, args.pv_lines, args.book, args.syzygy_path)?;
     let samples = generator.run(args.depth, stop_flag);
 
     log::info!("Generated {} samples", samples.len());

--- a/training/src/bin/generate/worker.rs
+++ b/training/src/bin/generate/worker.rs
@@ -2,7 +2,8 @@ use crate::book::Book;
 use crate::game::SelfPlayGame;
 use crate::histogram::HistogramHandle;
 use crate::samples::Sample;
-use search::{Engine, EngineConfig};
+use pyrrhic_rs::TableBases;
+use search::{CozyAdapter, Engine, EngineConfig};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
@@ -19,6 +20,7 @@ pub struct SelfPlayWorker {
     depth: u8,
     opening_book: Arc<Book>,
     histogram: HistogramHandle,
+    tablebases: Option<TableBases<CozyAdapter>>,
 }
 
 impl SelfPlayWorker {
@@ -33,15 +35,19 @@ impl SelfPlayWorker {
         create_evaluator: fn() -> nnue::Evaluator,
         opening_book: Arc<Book>,
         histogram: HistogramHandle,
+        tablebases: Option<TableBases<CozyAdapter>>,
     ) -> Self {
         let mut config = EngineConfig::default();
 
         config.hash_size.value = WORKER_HASH_SIZE_MB;
         config.multi_pv.value = multi_pv;
 
-        // Engine stop flag (not used in data generation, but required by Engine)
         let stop = Arc::new(AtomicBool::new(false));
         let engine = Engine::new(&config, stop, create_evaluator);
+
+        if let Some(ref tb) = tablebases {
+            engine.set_tablebases(tb.clone());
+        }
 
         Self {
             _tid: tid,
@@ -51,6 +57,7 @@ impl SelfPlayWorker {
             engine,
             opening_book,
             histogram,
+            tablebases,
         }
     }
 
@@ -61,7 +68,8 @@ impl SelfPlayWorker {
             let game_id = self.game_id_counter.fetch_add(1, Ordering::Relaxed);
             let opening_fen = self.opening_book.random_position();
 
-            let mut game = SelfPlayGame::new(game_id, opening_fen, self.depth);
+            let mut game =
+                SelfPlayGame::new(game_id, opening_fen, self.depth, self.tablebases.clone());
             game.play(&mut self.engine);
 
             let (samples, scores) = game.get_samples();

--- a/uci/src/options.rs
+++ b/uci/src/options.rs
@@ -8,6 +8,7 @@ pub struct UciOption {
 pub enum UciOptionType {
     Spin { min: i32, max: i32 },
     Check,
+    String,
 }
 
 impl UciOptionType {
@@ -26,6 +27,7 @@ impl UciOptionType {
                 "true" | "false" => Ok(()),
                 _ => Err("Boolean value must be 'true' or 'false'".to_string()),
             },
+            UciOptionType::String => Ok(()),
         }
     }
 
@@ -49,6 +51,14 @@ impl UciOptionType {
                     name,
                     current_value.to_string()
                 )
+            }
+            UciOptionType::String => {
+                let val = current_value.to_string();
+                if val.is_empty() {
+                    format!("option name {} type string default <empty>", name)
+                } else {
+                    format!("option name {} type string default {}", name, val)
+                }
             }
         }
     }

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -22,8 +22,8 @@ pub use material::{
 };
 pub use math::select_softmax;
 pub use moves::{
-    captured_piece, collect_legal_moves, gives_check, has_check, has_legal_moves, is_capture,
-    is_en_passant, make_move, only_move,
+    captured_piece, collect_legal_moves, en_passant_square, gives_check, has_check,
+    has_legal_moves, is_capture, is_en_passant, make_move, only_move,
 };
 pub use node::{Node, NodeType, creates_threat, evades_threat};
 pub use ply::FracPly;

--- a/utils/src/moves.rs
+++ b/utils/src/moves.rs
@@ -1,22 +1,22 @@
-use cozy_chess::{Board, Color, Move, Piece, Rank};
+use cozy_chess::{Board, Color, Move, Piece, Rank, Square};
 
-/// Check if a move is an en passant capture.
-pub fn is_en_passant(board: &Board, mv: Move) -> bool {
-    let Some(ep_file) = board.en_passant() else {
-        return false;
-    };
-
-    if mv.to.file() != ep_file || board.piece_on(mv.from) != Some(Piece::Pawn) {
-        return false;
-    }
-
-    let ep_rank = if board.side_to_move() == Color::White {
+/// Get the en passant target square, if any.
+pub fn en_passant_square(board: &Board) -> Option<Square> {
+    let file = board.en_passant()?;
+    let rank = if board.side_to_move() == Color::White {
         Rank::Sixth
     } else {
         Rank::Third
     };
+    Some(Square::new(file, rank))
+}
 
-    mv.to.rank() == ep_rank
+/// Check if a move is an en passant capture.
+pub fn is_en_passant(board: &Board, mv: Move) -> bool {
+    let Some(ep_sq) = en_passant_square(board) else {
+        return false;
+    };
+    mv.to == ep_sq && board.piece_on(mv.from) == Some(Piece::Pawn)
 }
 
 /// Check if a move is a capture (enemy piece on destination or en passant).


### PR DESCRIPTION
## Summary

Added Syzygy endgame tablebase support via [`pyrrhic-rs`](https://crates.io/crates/pyrrhic-rs), a Rust-based Syzygy prober that works natively with `cozy_chess`.

The engine can now load endgame tablebases and probe WDL during search, giving it perfect endgame knowledge instead of relying on the NNUE to figure out drawn KBvK positions at depth 8 (spoiler: it couldn't).

## What's in here

- **New `tablebase` module in `search`**: `CozyAdapter` wires `cozy_chess` attack generation into `pyrrhic-rs` (copy-pasted from their docs), plus `probe_wdl` / `wdl_to_score` for search integration
- **Search probing**: non-root nodes probe WDL when depth >= `SyzygyProbeDepth` and the position has few enough pieces + no castling rights. TB wins score just below mate so the TT's ply normalization handles them for free
- **UCI options**: `SyzygyPath` (colon-separated paths) and `SyzygyProbeDepth` (default 1)
- **Data generation**: optional `--syzygy-path` flag for the generator. Draws/cursed-wins/blessed-losses are adjudicated immediately, wins/losses play on so the NNUE still sees the positions

## Not in here (future)

- DTZ probing for root move ordering
- Storing TB results in the TT (perf optimization, the probe is cheap enough for now)
- TB-aware data generation with teleporting (the short PVs in endgames mess with teleporting... still figuring out the best approach)