### PR TITLE
perf: use SCReLU activation in NNUE

### DIFF
--- a/nnue/model.safetensors
+++ b/nnue/model.safetensors
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9e5b6b7c1ef16b2fbd51f7105667b0eadd0298030914db43b4c814f9e41058d3
+oid sha256:b21de0832322a4fb46df2bd69689112be3831e13394773aa5e25eff574b0f41f
 size 5265120

--- a/nnue/src/network/accumulator.rs
+++ b/nnue/src/network/accumulator.rs
@@ -105,9 +105,10 @@ impl Accumulator {
         }
     }
 
-    /// Converts the accumulated i16 buffer into f32 activations with ReLU applied.
-    pub fn dequantize_and_relu(&self, output: &mut [f32; EMBEDDING_SIZE]) {
+    /// Converts the accumulated i16 buffer into f32 activations with SCReLU applied.
+    pub fn dequantize_and_screlu(&self, output: &mut [f32; EMBEDDING_SIZE]) {
         let zeros = SimdF32::splat(0.0);
+        let ones = SimdF32::splat(1.0);
 
         let mut i = 0;
         while i + SIMD_WIDTH_F32 <= EMBEDDING_SIZE {
@@ -116,7 +117,8 @@ impl Accumulator {
             let scale_vec = SimdF32::from_slice(&self.inv_scales[i..i + SIMD_WIDTH_F32]);
 
             let dequantized = vals_f32 * scale_vec;
-            let activated = dequantized.simd_max(zeros); // ReLU
+            let clamped = dequantized.simd_max(zeros).simd_min(ones);
+            let activated = clamped * clamped;
 
             activated.copy_to_slice(&mut output[i..i + SIMD_WIDTH_F32]);
             i += SIMD_WIDTH_F32;
@@ -124,7 +126,8 @@ impl Accumulator {
 
         // Cleanup remaining outside SIMD width
         while i < EMBEDDING_SIZE {
-            output[i] = (self.buffer[i] as f32 * self.inv_scales[i]).max(0.0);
+            let clamped = (self.buffer[i] as f32 * self.inv_scales[i]).clamp(0.0, 1.0);
+            output[i] = clamped * clamped;
             i += 1;
         }
     }

--- a/nnue/src/network/inference.rs
+++ b/nnue/src/network/inference.rs
@@ -6,7 +6,7 @@ use crate::encoding::NUM_FEATURES;
 use super::accumulator::Accumulator;
 use super::linear::LinearLayer;
 use super::model::Network;
-use super::simd::{simd_add, simd_relu};
+use super::simd::{simd_add, simd_screlu};
 use super::{CP_BOUND, EMBEDDING_SIZE, FV_SCALE, HIDDEN_SIZE, OUTPUT_BUCKETS};
 
 /// NNUE inference engine with quantized weights.
@@ -54,7 +54,7 @@ impl NNUENetwork {
     pub fn forward(&mut self, bitset: &Bitset<NUM_FEATURES>, bucket: usize) -> f32 {
         self.accumulator.update(bitset);
         self.accumulator
-            .dequantize_and_relu(&mut self.embedding_buffer);
+            .dequantize_and_screlu(&mut self.embedding_buffer);
 
         let output = self.buckets[bucket].forward(&self.embedding_buffer);
 
@@ -76,11 +76,11 @@ impl OutputStack {
     #[inline]
     fn forward(&mut self, input: &[f32]) -> f32 {
         self.hidden1.forward(input, &mut self.h1_buffer);
-        simd_relu(&mut self.h1_buffer);
+        simd_screlu(&mut self.h1_buffer);
 
         self.hidden2.forward(&self.h1_buffer, &mut self.h2_buffer);
         simd_add(&mut self.h2_buffer, &self.h1_buffer); // residual connection
-        simd_relu(&mut self.h2_buffer);
+        simd_screlu(&mut self.h2_buffer);
 
         self.output.forward(&self.h2_buffer, &mut self.out_buffer);
 

--- a/nnue/src/network/model.rs
+++ b/nnue/src/network/model.rs
@@ -38,7 +38,7 @@ impl Network {
     /// selected bucket—unused buckets receive zero gradient for that sample.
     #[inline]
     pub fn forward(&self, x: &Tensor, buckets: &[usize]) -> Result<Tensor> {
-        let embedding_out = x.apply(&self.embedding)?.relu()?;
+        let embedding_out = screlu(&x.apply(&self.embedding)?)?;
 
         // Compute all bucket outputs: [batch, OUTPUT_BUCKETS]
         let all_outputs: Vec<_> = self
@@ -67,8 +67,12 @@ pub struct OutputStack {
 
 impl OutputStack {
     fn forward(&self, input: &Tensor) -> Result<Tensor> {
-        let h1 = input.apply(&self.hidden1)?.relu()?;
-        let h2 = (h1.apply(&self.hidden2)? + &h1)?.relu()?;
+        let h1 = screlu(&input.apply(&self.hidden1)?)?;
+        let h2 = screlu(&(h1.apply(&self.hidden2)? + &h1)?)?;
         h2.apply(&self.output)
     }
+}
+
+fn screlu(x: &Tensor) -> Result<Tensor> {
+    x.clamp(0.0f32, 1.0f32)?.sqr()
 }

--- a/nnue/src/network/simd.rs
+++ b/nnue/src/network/simd.rs
@@ -7,21 +7,22 @@ pub type SimdI16 = i16x32;
 pub const SIMD_WIDTH_F32: usize = 16;
 pub const SIMD_WIDTH_I16: usize = 32;
 
-pub fn simd_relu(values: &mut [f32]) {
+pub fn simd_screlu(values: &mut [f32]) {
     let len = values.len();
     let mut i = 0;
     let zeros = SimdF32::splat(0.0);
+    let ones = SimdF32::splat(1.0);
 
     while i + SIMD_WIDTH_F32 <= len {
         let chunk = SimdF32::from_slice(&values[i..i + SIMD_WIDTH_F32]);
-        chunk
-            .simd_max(zeros)
-            .copy_to_slice(&mut values[i..i + SIMD_WIDTH_F32]);
+        let clamped = chunk.simd_max(zeros).simd_min(ones);
+        (clamped * clamped).copy_to_slice(&mut values[i..i + SIMD_WIDTH_F32]);
         i += SIMD_WIDTH_F32;
     }
 
     for val in &mut values[i..len] {
-        *val = val.max(0.0);
+        let clamped = val.clamp(0.0, 1.0);
+        *val = clamped * clamped;
     }
 }
 


### PR DESCRIPTION
Because I know `SCReLU` is a fan favorite in modern engines.

There is an obvious facepalm with this implementation - the residuals are fed into the activation... and so the residual signals are being clipped too... which i believe is not great.

...buut, i had already trained for a day and saw reasonable loss and validation, so i let it run and i got a small positive result on STC (and noisy not-regressing-too-hard on LTC):

```
--------------------------------------------------
Results of grail vs grail-next (10+0.1, 1t, 256MB, UHO_Lichess_4852_v1.epd):
Elo: 5.21 +/- 7.65, nElo: 8.47 +/- 12.43
LOS: 90.91 %, DrawRatio: 46.00 %, PairsRatio: 1.11
Games: 3000, Wins: 942, Losses: 897, Draws: 1161, Points: 1522.5 (50.75 %)
Ptnml(0-2): [53, 331, 690, 370, 56], WL/DD Ratio: 2.00
--------------------------------------------------
```

```
--------------------------------------------------
Results of grail vs grail-next (60+0.6, 1t, 256MB, UHO_Lichess_4852_v1.epd):
Elo: -4.63 +/- 22.72, nElo: -8.03 +/- 39.32
LOS: 34.45 %, DrawRatio: 47.33 %, PairsRatio: 0.88
Games: 300, Wins: 86, Losses: 90, Draws: 124, Points: 148.0 (49.33 %)
Ptnml(0-2): [3, 39, 71, 33, 4], WL/DD Ratio: 1.73
--------------------------------------------------
```

Anyways... I trust STC more here and I will merge this and iterate on a new net that does residuals properly and maybe some other changes i have wanted to do.