### PR TITLE
feat: add nnue-analysis weight inspection tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL = /bin/bash
 
 .ONESHELL:
 
-.PHONY: grail tunable generate train clean
+.PHONY: grail tunable generate train clean nnue-analysis
 
 # Default to native optimization for local development.
 RUSTFLAGS = -C target-cpu=native
@@ -26,6 +26,9 @@ train:
 	else \
 		RUSTFLAGS="$(RUSTFLAGS)" cargo build --release -p training --bin train; \
 	fi
+
+nnue-analysis:
+	RUSTFLAGS="$(RUSTFLAGS)" cargo run --release -p nnue --bin nnue-analysis
 
 clean:
 	cargo clean

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The project includes a `Makefile` for convenience:
 - **`make tunable`**: Builds with exposed parameters for SPSA tuning.
 - **`make generate`**: Builds the data generation tool for NNUE training.
 - **`make train`**: Builds the NNUE trainer (auto-detects CUDA/Metal).
+- **`make nnue-analysis`**: Dumps a human-readable weight analysis of the current NNUE to `nnue/model.analysis.txt`.
 - **`make clean`**: Cleans the build directory.
 
 ### Benchmarking

--- a/nnue/Cargo.toml
+++ b/nnue/Cargo.toml
@@ -29,5 +29,9 @@ metal = [
 [lib]
 name = "nnue"
 
+[[bin]]
+name = "nnue-analysis"
+path = "src/bin/analysis/main.rs"
+
 [lints]
 workspace = true

--- a/nnue/model.analysis.txt
+++ b/nnue/model.analysis.txt
@@ -1,0 +1,232 @@
+embedding (1153 -> 1024) ===========================================
+  weight:  mean 0.0607, median 0.0322, std 0.1042, max 1.9266, scale 4.12x, CoV 1.72, dead 3.1%
+  neurons: 1024/1024 active, row norm min 1.900 / mean 3.480 / max 10.028
+  bias:    mean -0.1778 (|b| mean 0.2086, max 0.6275)
+
+  feature groups (column norms, x pieces):
+    pieces   ( 768 feats): norm 3.7408 (1.00x)
+    support  ( 128 feats): norm 1.3696 (0.37x)
+    space    ( 128 feats): norm 1.1618 (0.31x)
+    threats  ( 128 feats): norm 3.0615 (0.82x)
+    stm      (   1 feats): norm 6.5473 (1.75x)
+
+  piece types (column norms, x pawn):
+    pawn   (128 feats): norm 2.9953 (1.00x)
+    knight (128 feats): norm 3.3467 (1.12x)
+    bishop (128 feats): norm 3.5546 (1.19x)
+    rook   (128 feats): norm 3.4258 (1.14x)
+    queen  (128 feats): norm 4.1350 (1.38x)
+    king   (128 feats): norm 4.9875 (1.67x)
+
+piece heatmaps (col norm per square, white | black) ================
+  pawn   white (0.000 - 5.053)     black (0.000 - 4.741)
+      a  b  c  d  e  f  g  h       a  b  c  d  e  f  g  h
+    8                            8                        
+    7 ██ ██ ██ ██ ██ ██ ██ ██    7 ▓▓ ██ ▓▓ ▓▓ ▓▓ ██ ██ ▓▓
+    6 ▓▓ ▓▓ ▓▓ ▓▓ ██ ██ ██ ██    6 ▓▓ ▓▓ ██ ██ ██ ██ ██ ▓▓
+    5 ▓▓ ▓▓ ▓▓ ██ ██ ▓▓ ▓▓ ▓▓    5 ▓▓ ▓▓ ▓▓ ██ ██ ██ ██ ▓▓
+    4 ▓▓ ▓▓ ▓▓ ▓▓ ██ ▓▓ ▓▓ ▓▓    4 ▓▓ ▓▓ ▓▓ ██ ▓▓ ██ ▓▓ ██
+    3 ▓▓ ▓▓ ▓▓ ▓▓ ██ ▓▓ ██ ▓▓    3 ▓▓ ██ ██ ██ ██ ██ ██ ██
+    2 ▓▓ ▓▓ ▓▓ ▓▓ ▓▓ ██ ██ ▓▓    2 ██ ██ ██ ██ ██ ██ ██ ██
+    1                            1                        
+
+  knight white (2.952 - 3.903)     black (2.982 - 3.716)
+      a  b  c  d  e  f  g  h       a  b  c  d  e  f  g  h
+    8 ▓▓ ▒▒ ▒▒ ▓▓ ▓▓ ██ ██ ██    8 ██ ▓▓ ░░    ░░ ░░ ▒▒ ▓▓
+    7 ▓▓ ▒▒ ▓▓ ██ ▓▓ ██ ▒▒ ██    7 ▒▒ ░░    ░░ ░░         
+    6 ▒▒ ░░ ▒▒ ▒▒ ▓▓ ▒▒ ▒▒ ▓▓    6       ░░    ░░         
+    5 ░░ ░░ ░░ ▒▒ ░░ ▒▒ ▓▓ ▒▒    5 ░░       ░░ ░░ ▒▒ ░░ ░░
+    4 ░░    ▒▒ ░░ ▓▓ ▒▒ ▒▒ ▒▒    4 ░░ ░░ ░░ ▒▒ ░░ ▒▒ ▓▓ ░░
+    3 ░░ ░░ ▒▒    ░░ ▒▒ ░░ ░░    3 ░░    ▒▒ ░░ ▒▒ ▓▓ ░░ ▓▓
+    2 ░░ ▒▒    ░░ ░░    ░░ ▒▒    2 ░░ ░░ ▒▒ ▒▒ ██ ▒▒ ▒▒ ▓▓
+    1 ▓▓ ▓▓       ░░ ░░ ▒▒ ██    1 ██ ░░ ▓▓ ▒▒ ▒▒ ██ ██ ██
+
+  bishop white (3.124 - 4.269)     black (3.162 - 4.210)
+      a  b  c  d  e  f  g  h       a  b  c  d  e  f  g  h
+    8 ▒▒ ░░ ░░ ░░ ░░ ▒▒ ▓▓ ▒▒    8 ██ ▓▓ ▒▒ ░░    ▒▒ ▓▓ ██
+    7 ▒▒ ░░    ░░ ▒▒ ▒▒ ░░ ▒▒    7 ▓▓ ▒▒ ░░    ░░ ░░ ▒▒ ▒▒
+    6 ░░    ░░ ▒▒ ▒▒ ░░ ░░ ▒▒    6 ▒▒ ▒▒ ░░    ░░ ░░ ▒▒ ░░
+    5       ░░ ▒▒ ▒▒ ░░ ░░ ░░    5 ░░    ░░ ░░ ░░ ▒▒ ▒▒   
+    4 ░░ ░░ ░░ ░░ ▒▒ ▒▒ ░░ ░░    4       ░░ ▒▒ ▒▒ ░░ ░░   
+    3 ░░ ▒▒ ░░ ▒▒ ░░ ░░ ▒▒ ░░    3          ▒▒ ░░ ░░ ░░ ░░
+    2 ▒▒ ▓▓ ░░ ░░ ░░ ░░ ▓▓ ▒▒    2 ▒▒       ░░ ░░ ░░ ░░ ▒▒
+    1 ▓▓ ▓▓ ▒▒ ░░ ░░ ░░ ▓▓ ██    1 ░░ ░░ ░░ ░░ ░░ ▒▒ ▒▒ ░░
+
+  rook   white (3.094 - 3.884)     black (3.089 - 3.988)
+      a  b  c  d  e  f  g  h       a  b  c  d  e  f  g  h
+    8 ▒▒ ▒▒ ▒▒ ▓▓ ▓▓ ██ ▓▓ ▓▓    8 ██ ▓▓    ░░ ░░    ▓▓ ██
+    7 ▒▒ ▒▒ ▓▓ ▒▒ ▒▒ ▓▓ ██ ██    7 ▒▒ ░░       ░░ ░░ ▒▒ ▒▒
+    6 ▓▓ ▒▒ ▒▒ ▒▒ ▒▒ ▒▒ ▓▓ ▒▒    6 ░░       ░░    ░░ ░░ ▒▒
+    5 ▒▒ ░░ ░░    ░░ ░░ ▒▒ ░░    5                   ░░ ░░
+    4                   ░░ ░░    4 ░░ ░░          ░░ ░░ ░░
+    3             ░░    ░░ ░░    3 ░░ ░░ ░░ ░░ ░░ ▒▒ ▒▒ ▒▒
+    2 ▒▒ ░░       ░░ ▒▒ ▒▒ ██    2 ▒▒ ░░ ░░ ▒▒ ▒▒ ▓▓ ▓▓ ▓▓
+    1 ██ ▒▒ ░░ ▒▒ ░░ ░░ ▓▓ ██    1 ░░ ▒▒ ░░ ▒▒ ▓▓ ▓▓ ██ ▒▒
+
+  queen  white (3.895 - 4.934)     black (3.787 - 4.631)
+      a  b  c  d  e  f  g  h       a  b  c  d  e  f  g  h
+    8 ▒▒ ▒▒ ▒▒ ▒▒ ▓▓ ▓▓ ██ ██    8 ░░ ▒▒             ░░ ▓▓
+    7 ░░ ░░ ▒▒ ░░ ▒▒ ▒▒ ▓▓ ▓▓    7                      ░░
+    6       ░░ ░░ ░░ ▓▓ ▒▒ ▒▒    6    ░░ ░░          ░░ ▒▒
+    5          ░░ ░░ ░░ ░░ ░░    5                      ░░
+    4                ░░    ░░    4 ░░ ░░ ░░ ░░ ░░    ░░ ▒▒
+    3                      ░░    3 ░░ ░░ ░░ ▒▒ ▒▒ ▓▓ ▒▒ ▓▓
+    2       ░░          ░░ ░░    2 ▒▒ ▒▒ ▒▒ ░░ ▒▒ ▓▓ ▓▓ ██
+    1 ░░                   ▒▒    1 ▒▒ ▒▒ ▒▒ ▒▒ ▓▓ ██ ██ ██
+
+  king   white (4.233 - 6.125)     black (4.339 - 6.290)
+      a  b  c  d  e  f  g  h       a  b  c  d  e  f  g  h
+    8 ▒▒ ▒▒ ▒▒ ░░ ░░ ▒▒ ▒▒ ▒▒    8 ██ ██ ▓▓ ▒▒ ▒▒ ░░ ▒▒ ▓▓
+    7 ▒▒ ▒▒ ▒▒ ░░ ░░ ▒▒ ▒▒ ▓▓    7 ██ ▓▓ ▒▒ ░░ ░░    ░░ ▒▒
+    6 ▒▒ ▒▒ ░░ ░░    ▒▒ ▒▒ ▒▒    6 ▒▒ ▒▒ ▒▒             ░░
+    5 ▒▒ ▒▒ ░░       ░░ ░░ ░░    5 ░░ ░░                  
+    4 ▒▒ ░░                      4 ░░ ░░             ░░ ░░
+    3 ▓▓ ▒▒ ░░          ░░ ░░    3 ░░ ░░ ░░       ░░ ▒▒ ░░
+    2 ▓▓ ▓▓ ▒▒ ░░       ░░ ▒▒    2 ░░ ▒▒ ▒▒ ░░ ░░ ░░ ▒▒ ▒▒
+    1 ██ ██ ▓▓ ░░ ▒▒ ░░ ▒▒ ▓▓    1 ▒▒ ░░ ░░ ░░    ░░ ░░ ▒▒
+
+bucket 0 ===========================================================
+  hidden1 (1024 -> 16):
+    weight:  mean 0.0622, median 0.0248, std 0.1218, max 2.4030, scale 3.98x, CoV 1.96, rel 0.04x, dead 31.4%
+    neurons: 11/16 active, row norm min 0.000 / mean 3.167 / max 7.091
+    bias:    mean +0.0205 (|b| mean 0.0425, max 0.1758)
+  hidden2 (16 -> 16):
+    weight:  mean 0.3457, median 0.1623, std 0.5824, max 2.6383, scale 2.77x, CoV 1.68, rel 0.20x, dead 31.2%
+    neurons: 16/16 active, row norm min 1.584 / mean 2.254 / max 3.523
+    bias:    mean +0.0166 (|b| mean 0.0829, max 0.1947)
+  output (16 -> 1):
+    weight:  mean 1.7727, median 2.0197, std 2.1232, max 4.2513, scale 14.18x, CoV 1.20, rel 1.00x, dead 0.0%
+    neurons: 1/1 active, row norm min 8.593 / mean 8.593 / max 8.593
+    bias:    mean +0.0563 (|b| mean 0.0563, max 0.0563)
+
+bucket 1 ===========================================================
+  hidden1 (1024 -> 16):
+    weight:  mean 0.0490, median 0.0162, std 0.0995, max 1.5779, scale 3.14x, CoV 2.03, rel 0.03x, dead 31.4%
+    neurons: 11/16 active, row norm min 0.000 / mean 2.629 / max 4.334
+    bias:    mean +0.0187 (|b| mean 0.0234, max 0.1200)
+  hidden2 (16 -> 16):
+    weight:  mean 0.3030, median 0.1201, std 0.5821, max 2.7914, scale 2.42x, CoV 1.92, rel 0.20x, dead 31.2%
+    neurons: 16/16 active, row norm min 1.122 / mean 2.238 / max 3.716
+    bias:    mean +0.0454 (|b| mean 0.1000, max 0.3705)
+  output (16 -> 1):
+    weight:  mean 1.5162, median 1.1658, std 1.7545, max 3.3996, scale 12.13x, CoV 1.16, rel 1.00x, dead 0.0%
+    neurons: 1/1 active, row norm min 7.057 / mean 7.057 / max 7.057
+    bias:    mean -0.0290 (|b| mean 0.0290, max 0.0290)
+
+bucket 2 ===========================================================
+  hidden1 (1024 -> 16):
+    weight:  mean 0.0608, median 0.0273, std 0.1141, max 1.1480, scale 3.89x, CoV 1.88, rel 0.04x, dead 19.1%
+    neurons: 13/16 active, row norm min 0.000 / mean 3.259 / max 5.419
+    bias:    mean +0.0209 (|b| mean 0.0393, max 0.1826)
+  hidden2 (16 -> 16):
+    weight:  mean 0.3019, median 0.1656, std 0.5402, max 3.3504, scale 2.42x, CoV 1.79, rel 0.20x, dead 18.8%
+    neurons: 16/16 active, row norm min 1.048 / mean 2.023 / max 3.546
+    bias:    mean -0.0069 (|b| mean 0.0985, max 0.3573)
+  output (16 -> 1):
+    weight:  mean 1.5109, median 1.2723, std 1.7491, max 3.5156, scale 12.09x, CoV 1.16, rel 1.00x, dead 0.0%
+    neurons: 1/1 active, row norm min 7.061 / mean 7.061 / max 7.061
+    bias:    mean +0.0955 (|b| mean 0.0955, max 0.0955)
+
+bucket 3 ===========================================================
+  hidden1 (1024 -> 16):
+    weight:  mean 0.0485, median 0.0000, std 0.1286, max 1.5624, scale 3.11x, CoV 2.65, rel 0.03x, dead 56.5%
+    neurons: 7/16 active, row norm min 0.000 / mean 2.651 / max 8.428
+    bias:    mean +0.0349 (|b| mean 0.0414, max 0.2295)
+  hidden2 (16 -> 16):
+    weight:  mean 0.1360, median 0.0000, std 0.2901, max 1.4632, scale 1.09x, CoV 2.13, rel 0.08x, dead 59.0%
+    neurons: 10/16 active, row norm min 0.000 / mean 1.075 / max 1.800
+    bias:    mean -0.0164 (|b| mean 0.1164, max 0.3591)
+  output (16 -> 1):
+    weight:  mean 1.6116, median 1.7937, std 1.8797, max 3.4995, scale 12.89x, CoV 1.17, rel 1.00x, dead 6.2%
+    neurons: 1/1 active, row norm min 7.520 / mean 7.520 / max 7.520
+    bias:    mean +0.1101 (|b| mean 0.1101, max 0.1101)
+
+bucket 4 ===========================================================
+  hidden1 (1024 -> 16):
+    weight:  mean 0.0473, median 0.0000, std 0.1278, max 2.1971, scale 3.03x, CoV 2.70, rel 0.04x, dead 56.7%
+    neurons: 7/16 active, row norm min 0.000 / mean 2.648 / max 7.571
+    bias:    mean +0.0474 (|b| mean 0.0474, max 0.3057)
+  hidden2 (16 -> 16):
+    weight:  mean 0.1227, median 0.0000, std 0.3034, max 3.0608, scale 0.98x, CoV 2.47, rel 0.10x, dead 61.7%
+    neurons: 4/16 active, row norm min 0.000 / mean 0.950 / max 3.500
+    bias:    mean -0.0202 (|b| mean 0.1344, max 0.6545)
+  output (16 -> 1):
+    weight:  mean 1.2038, median 1.1580, std 1.3703, max 2.7625, scale 9.63x, CoV 1.14, rel 1.00x, dead 12.5%
+    neurons: 1/1 active, row norm min 5.708 / mean 5.708 / max 5.708
+    bias:    mean +0.0426 (|b| mean 0.0426, max 0.0426)
+
+bucket 5 ===========================================================
+  hidden1 (1024 -> 16):
+    weight:  mean 0.0196, median 0.0000, std 0.0894, max 2.1120, scale 1.25x, CoV 4.56, rel 0.01x, dead 81.6%
+    neurons: 3/16 active, row norm min 0.000 / mean 1.207 / max 8.488
+    bias:    mean +0.0238 (|b| mean 0.0238, max 0.2197)
+  hidden2 (16 -> 16):
+    weight:  mean 0.0836, median 0.0000, std 0.2878, max 3.0446, scale 0.67x, CoV 3.44, rel 0.05x, dead 82.4%
+    neurons: 3/16 active, row norm min 0.000 / mean 0.930 / max 3.079
+    bias:    mean -0.0191 (|b| mean 0.1766, max 0.5056)
+  output (16 -> 1):
+    weight:  mean 1.7611, median 1.7490, std 1.9832, max 3.6113, scale 14.09x, CoV 1.13, rel 1.00x, dead 6.2%
+    neurons: 1/1 active, row norm min 7.957 / mean 7.957 / max 7.957
+    bias:    mean +0.1797 (|b| mean 0.1797, max 0.1797)
+
+bucket 6 ===========================================================
+  hidden1 (1024 -> 16):
+    weight:  mean 0.0418, median 0.0000, std 0.1156, max 1.5276, scale 2.68x, CoV 2.76, rel 0.04x, dead 63.6%
+    neurons: 6/16 active, row norm min 0.000 / mean 2.257 / max 7.142
+    bias:    mean +0.0477 (|b| mean 0.0477, max 0.2199)
+  hidden2 (16 -> 16):
+    weight:  mean 0.0972, median 0.0000, std 0.2340, max 1.2514, scale 0.78x, CoV 2.41, rel 0.09x, dead 71.9%
+    neurons: 6/16 active, row norm min 0.000 / mean 0.764 / max 1.635
+    bias:    mean -0.0594 (|b| mean 0.1194, max 0.4883)
+  output (16 -> 1):
+    weight:  mean 1.0583, median 1.2691, std 1.3605, max 2.6908, scale 8.47x, CoV 1.29, rel 1.00x, dead 25.0%
+    neurons: 1/1 active, row norm min 5.453 / mean 5.453 / max 5.453
+    bias:    mean -0.1582 (|b| mean 0.1582, max 0.1582)
+
+bucket 7 ===========================================================
+  hidden1 (1024 -> 16):
+    weight:  mean 0.0145, median 0.0000, std 0.0689, max 2.4925, scale 0.93x, CoV 4.74, rel 0.02x, dead 88.3%
+    neurons: 2/16 active, row norm min 0.000 / mean 0.778 / max 6.665
+    bias:    mean +0.0058 (|b| mean 0.0058, max 0.0602)
+  hidden2 (16 -> 16):
+    weight:  mean 0.0391, median 0.0000, std 0.2446, max 3.2390, scale 0.31x, CoV 6.26, rel 0.05x, dead 93.0%
+    neurons: 4/16 active, row norm min 0.000 / mean 0.541 / max 3.263
+    bias:    mean +0.0132 (|b| mean 0.0643, max 0.1975)
+  output (16 -> 1):
+    weight:  mean 0.8304, median 0.6760, std 1.2641, max 2.7141, scale 6.64x, CoV 1.52, rel 1.00x, dead 43.8%
+    neurons: 1/1 active, row norm min 5.085 / mean 5.085 / max 5.085
+    bias:    mean +0.0775 (|b| mean 0.0775, max 0.0775)
+
+summary (across 8 buckets) =========================================
+  scale (x init):
+    hidden1: avg 2.75x (range 0.93x - 3.98x)
+    hidden2: avg 1.43x (range 0.31x - 2.77x)
+    output : avg 11.26x (range 6.64x - 14.18x)
+
+  dead weight fraction:
+    hidden1: avg 53.6% (range 19.1% - 88.3%)
+    hidden2: avg 56.2% (range 18.8% - 93.0%)
+    output : avg 11.7% (range 0.0% - 43.8%)
+
+  active neurons (of 16):
+    hidden1: avg 7.5 (range 2.0 - 13.0)
+    hidden2: avg 9.4 (range 3.0 - 16.0)
+
+  CoV (std / mean |W|):
+    hidden1: avg 2.91 (range 1.88 - 4.74)
+    hidden2: avg 2.76 (range 1.68 - 6.26)
+    output : avg 1.22 (range 1.13 - 1.52)
+
+  rel (x bucket output mean |W|):
+    hidden1: avg 0.03x (range 0.01x - 0.04x)
+    hidden2: avg 0.12x (range 0.05x - 0.20x)
+
+bucket output similarity (cosine) ==================================
+         b1    b2    b3    b4    b5    b6    b7
+  b0   0.15 -0.01 -0.12 -0.03  0.56  0.11 -0.45
+  b1         0.05  0.10 -0.28  0.28 -0.36 -0.05
+  b2               0.20 -0.35  0.29 -0.69 -0.34
+  b3                     0.05  0.31 -0.08 -0.20
+  b4                          -0.45  0.13  0.16
+  b5                                 0.02 -0.28
+  b6                                       0.13

--- a/nnue/src/bin/analysis/main.rs
+++ b/nnue/src/bin/analysis/main.rs
@@ -1,0 +1,30 @@
+//! Dumps a weight analysis of the trained NNUE to a text file.
+//! Useful during training to eyeball how the layers are actually behaving.
+
+mod math;
+mod report;
+mod stats;
+
+use candle_core::{DType, Device};
+use candle_nn::{VarBuilder, VarMap};
+use nnue::network::Network;
+use std::error::Error;
+use std::fs;
+use std::path::Path;
+
+const MODEL_PATH: &str = "nnue/model.safetensors";
+const ANALYSIS_PATH: &str = "nnue/model.analysis.txt";
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let mut varmap = VarMap::new();
+    let vs = VarBuilder::from_varmap(&varmap, DType::F32, &Device::Cpu);
+    let network = Network::new(&vs)?;
+    varmap.load(Path::new(MODEL_PATH))?;
+
+    let analysis = report::create(&network)?;
+
+    fs::write(ANALYSIS_PATH, &analysis)?;
+    println!("Analysis saved to {ANALYSIS_PATH}");
+
+    Ok(())
+}

--- a/nnue/src/bin/analysis/math.rs
+++ b/nnue/src/bin/analysis/math.rs
@@ -1,0 +1,65 @@
+pub fn mean(values: &[f32]) -> f32 {
+    values.iter().sum::<f32>() / values.len() as f32
+}
+
+pub fn mean_abs(values: &[f32]) -> f32 {
+    values.iter().map(|v| v.abs()).sum::<f32>() / values.len() as f32
+}
+
+pub fn median_abs(values: &[f32]) -> f32 {
+    let mut abs: Vec<f32> = values.iter().map(|v| v.abs()).collect();
+    // total_cmp so a stray NaN doesn't poison the sort.
+    abs.sort_by(f32::total_cmp);
+    abs[abs.len() / 2]
+}
+
+pub fn std_dev(values: &[f32]) -> f32 {
+    let m = mean(values);
+    let var = values.iter().map(|v| (v - m).powi(2)).sum::<f32>() / values.len() as f32;
+    var.sqrt()
+}
+
+pub fn max_abs(values: &[f32]) -> f32 {
+    values.iter().map(|v| v.abs()).fold(0.0, f32::max)
+}
+
+pub fn min_of(values: &[f32]) -> f32 {
+    values.iter().copied().fold(f32::INFINITY, f32::min)
+}
+
+pub fn max_of(values: &[f32]) -> f32 {
+    values.iter().copied().fold(f32::NEG_INFINITY, f32::max)
+}
+
+/// L2 norm of each input column (fan_in columns). Useful for feature importance.
+pub fn col_norms(weights: &[f32], fan_in: usize) -> Vec<f32> {
+    let mut sq_sums = vec![0.0f32; fan_in];
+    for row in weights.chunks_exact(fan_in) {
+        for (s, &w) in sq_sums.iter_mut().zip(row) {
+            *s += w * w;
+        }
+    }
+    for s in &mut sq_sums {
+        *s = s.sqrt();
+    }
+    sq_sums
+}
+
+/// L2 norm of each output row (one per output neuron).
+pub fn row_norms(weights: &[f32], fan_in: usize) -> Vec<f32> {
+    weights
+        .chunks_exact(fan_in)
+        .map(|row| row.iter().map(|w| w * w).sum::<f32>().sqrt())
+        .collect()
+}
+
+pub fn cosine(a: &[f32], b: &[f32]) -> f32 {
+    let dot: f32 = a.iter().zip(b).map(|(x, y)| x * y).sum();
+    let na = a.iter().map(|v| v * v).sum::<f32>().sqrt();
+    let nb = b.iter().map(|v| v * v).sum::<f32>().sqrt();
+    if na == 0.0 || nb == 0.0 {
+        0.0
+    } else {
+        dot / (na * nb)
+    }
+}

--- a/nnue/src/bin/analysis/report.rs
+++ b/nnue/src/bin/analysis/report.rs
@@ -1,0 +1,311 @@
+use candle_nn::Linear;
+use cozy_chess::Square;
+use nnue::encoding::NUM_FEATURES;
+use nnue::network::model::OutputStack;
+use nnue::network::{EMBEDDING_SIZE, HIDDEN_SIZE, Network, OUTPUT_BUCKETS};
+use std::error::Error;
+use std::fmt::{self, Write};
+
+use crate::math::{col_norms, cosine, max_of, mean, min_of};
+use crate::stats::{BucketStats, FEATURE_GROUPS, LayerStats, PIECE_TYPES, PIECES_PER_SQUARE};
+
+/// Total width of the `header ====` section rulers.
+const HEADER_WIDTH: usize = 68;
+
+pub fn create(network: &Network) -> Result<String, Box<dyn Error>> {
+    let mut out = String::new();
+
+    write_embedding(&mut out, &network.embedding)?;
+    write_piece_heatmaps(&mut out, &network.embedding)?;
+
+    let bucket_stats = write_buckets(&mut out, &network.buckets)?;
+    write_summary(&mut out, &bucket_stats)?;
+    writeln!(&mut out)?;
+    write_bucket_similarity(&mut out, &network.buckets)?;
+
+    Ok(out)
+}
+
+fn write_header(out: &mut String, title: &str) -> fmt::Result {
+    let bar = "=".repeat(HEADER_WIDTH.saturating_sub(title.len() + 1));
+    writeln!(out, "{title} {bar}")
+}
+
+fn write_embedding(out: &mut String, embedding: &Linear) -> Result<(), Box<dyn Error>> {
+    let stats = LayerStats::from_linear(embedding)?;
+    let weights = embedding.weight().flatten_all()?.to_vec1::<f32>()?;
+    let fan_in = embedding.weight().dim(1)?;
+    let norms = col_norms(&weights, fan_in);
+
+    write_header(
+        out,
+        &format!("embedding ({NUM_FEATURES} -> {EMBEDDING_SIZE})"),
+    )?;
+    write_layer(out, &stats, "  ")?;
+    writeln!(out)?;
+
+    // Feature groups, normalized to pieces mean so the scale reads as "x pieces".
+    let pieces = &FEATURE_GROUPS[0];
+    let pieces_mean = mean(&norms[pieces.start..pieces.end]);
+    writeln!(out, "  feature groups (column norms, x pieces):")?;
+    for g in FEATURE_GROUPS {
+        let m = mean(&norms[g.start..g.end]);
+        writeln!(
+            out,
+            "    {:8} ({:4} feats): norm {:.4} ({:.2}x)",
+            g.name,
+            g.len(),
+            m,
+            m / pieces_mean,
+        )?;
+    }
+    writeln!(out)?;
+
+    // Piece-type means combine both colors so the number reads as total weight
+    // the net gives to e.g. all knights across the board.
+    writeln!(out, "  piece types (column norms, x pawn):")?;
+    let pawn_mean = piece_type_mean(&norms, PIECE_TYPES[0].1, PIECE_TYPES[0].2);
+    for &(name, white_off, black_off) in PIECE_TYPES {
+        let m = piece_type_mean(&norms, white_off, black_off);
+        writeln!(
+            out,
+            "    {:6} ({:3} feats): norm {:.4} ({:.2}x)",
+            name,
+            Square::NUM * 2,
+            m,
+            m / pawn_mean,
+        )?;
+    }
+    writeln!(out)?;
+    Ok(())
+}
+
+fn piece_type_mean(col_norms: &[f32], white_off: usize, black_off: usize) -> f32 {
+    let mut sum = 0.0;
+    for sq in 0..Square::NUM {
+        sum += col_norms[sq * PIECES_PER_SQUARE + white_off];
+        sum += col_norms[sq * PIECES_PER_SQUARE + black_off];
+    }
+    sum / (Square::NUM * 2) as f32
+}
+
+// Side-by-side 8x8 heatmaps per piece type, white on the left, black on the right.
+// Each side is normalized against its own range so any color asymmetry is obvious.
+// Relevant since the embedding treats white and black as fully independent features.
+fn write_piece_heatmaps(out: &mut String, embedding: &Linear) -> Result<(), Box<dyn Error>> {
+    let weights = embedding.weight().flatten_all()?.to_vec1::<f32>()?;
+    let fan_in = embedding.weight().dim(1)?;
+    let norms = col_norms(&weights, fan_in);
+
+    write_header(out, "piece heatmaps (col norm per square, white | black)")?;
+    for &(name, white_off, black_off) in PIECE_TYPES {
+        let white = per_square_norms(&norms, white_off);
+        let black = per_square_norms(&norms, black_off);
+        let (wmin, wmax) = (min_of(&white), max_of(&white));
+        let (bmin, bmax) = (min_of(&black), max_of(&black));
+
+        writeln!(
+            out,
+            "  {name:6} white ({wmin:.3} - {wmax:.3})     black ({bmin:.3} - {bmax:.3})",
+        )?;
+        writeln!(
+            out,
+            "      a  b  c  d  e  f  g  h       a  b  c  d  e  f  g  h"
+        )?;
+        for rank in (0..8).rev() {
+            write_rank(out, "    ", rank, &white, wmin, wmax)?;
+            write!(out, "    ")?;
+            write_rank(out, "", rank, &black, bmin, bmax)?;
+            writeln!(out)?;
+        }
+        writeln!(out)?;
+    }
+    Ok(())
+}
+
+fn per_square_norms(col_norms: &[f32], offset: usize) -> Vec<f32> {
+    (0..Square::NUM)
+        .map(|sq| col_norms[sq * PIECES_PER_SQUARE + offset])
+        .collect()
+}
+
+fn write_rank(
+    out: &mut String,
+    indent: &str,
+    rank: usize,
+    per_square: &[f32],
+    min: f32,
+    max: f32,
+) -> fmt::Result {
+    write!(out, "{indent}{}", rank + 1)?;
+    let range = (max - min).max(f32::EPSILON);
+    for file in 0..8 {
+        let sq = rank * 8 + file;
+        let shade = match ((per_square[sq] - min) / range * 5.0) as usize {
+            0 => "  ",
+            1 => "░░",
+            2 => "▒▒",
+            3 => "▓▓",
+            _ => "██",
+        };
+        write!(out, " {shade}")?;
+    }
+    Ok(())
+}
+
+fn write_buckets(
+    out: &mut String,
+    buckets: &[OutputStack; OUTPUT_BUCKETS],
+) -> Result<Vec<BucketStats>, Box<dyn Error>> {
+    let mut all = Vec::with_capacity(OUTPUT_BUCKETS);
+    for (i, stack) in buckets.iter().enumerate() {
+        let stats = BucketStats::from_stack(stack)?;
+
+        write_header(out, &format!("bucket {i}"))?;
+        writeln!(out, "  hidden1 ({EMBEDDING_SIZE} -> {HIDDEN_SIZE}):")?;
+        write_layer(out, &stats.h1, "    ")?;
+        writeln!(out, "  hidden2 ({HIDDEN_SIZE} -> {HIDDEN_SIZE}):")?;
+        write_layer(out, &stats.h2, "    ")?;
+        writeln!(out, "  output ({HIDDEN_SIZE} -> 1):")?;
+        write_layer(out, &stats.output, "    ")?;
+        writeln!(out)?;
+
+        all.push(stats);
+    }
+    Ok(all)
+}
+
+fn write_layer(out: &mut String, s: &LayerStats, indent: &str) -> fmt::Result {
+    let rel = match s.rel_to_ref {
+        Some(r) => format!(", rel {r:.2}x"),
+        None => String::new(),
+    };
+    writeln!(
+        out,
+        "{indent}weight:  mean {:.4}, median {:.4}, std {:.4}, max {:.4}, scale {:.2}x, CoV {:.2}{rel}, dead {:.1}%",
+        s.weight_mean_abs,
+        s.weight_median_abs,
+        s.weight_std,
+        s.weight_max_abs,
+        s.scale,
+        s.cov,
+        s.dead_fraction * 100.0,
+    )?;
+    writeln!(
+        out,
+        "{indent}neurons: {}/{} active, row norm min {:.3} / mean {:.3} / max {:.3}",
+        s.active_neurons, s.total_neurons, s.row_norm_min, s.row_norm_mean, s.row_norm_max,
+    )?;
+    writeln!(
+        out,
+        "{indent}bias:    mean {:+.4} (|b| mean {:.4}, max {:.4})",
+        s.bias_mean_signed, s.bias_mean_abs, s.bias_max_abs,
+    )
+}
+
+fn write_summary(out: &mut String, buckets: &[BucketStats]) -> fmt::Result {
+    write_header(out, &format!("summary (across {} buckets)", buckets.len()))?;
+
+    let h1_scale: Vec<f32> = buckets.iter().map(|b| b.h1.scale).collect();
+    let h2_scale: Vec<f32> = buckets.iter().map(|b| b.h2.scale).collect();
+    let out_scale: Vec<f32> = buckets.iter().map(|b| b.output.scale).collect();
+    writeln!(out, "  scale (x init):")?;
+    summary_row(out, "hidden1", &h1_scale, "x", 2)?;
+    summary_row(out, "hidden2", &h2_scale, "x", 2)?;
+    summary_row(out, "output", &out_scale, "x", 2)?;
+    writeln!(out)?;
+
+    // Pre-scale to percent so the helper stays simple.
+    let h1_dead: Vec<f32> = buckets.iter().map(|b| b.h1.dead_fraction * 100.0).collect();
+    let h2_dead: Vec<f32> = buckets.iter().map(|b| b.h2.dead_fraction * 100.0).collect();
+    let out_dead: Vec<f32> = buckets
+        .iter()
+        .map(|b| b.output.dead_fraction * 100.0)
+        .collect();
+    writeln!(out, "  dead weight fraction:")?;
+    summary_row(out, "hidden1", &h1_dead, "%", 1)?;
+    summary_row(out, "hidden2", &h2_dead, "%", 1)?;
+    summary_row(out, "output", &out_dead, "%", 1)?;
+    writeln!(out)?;
+
+    let h1_active: Vec<f32> = buckets.iter().map(|b| b.h1.active_neurons as f32).collect();
+    let h2_active: Vec<f32> = buckets.iter().map(|b| b.h2.active_neurons as f32).collect();
+    writeln!(out, "  active neurons (of {HIDDEN_SIZE}):")?;
+    summary_row(out, "hidden1", &h1_active, "", 1)?;
+    summary_row(out, "hidden2", &h2_active, "", 1)?;
+    writeln!(out)?;
+
+    let h1_cov: Vec<f32> = buckets.iter().map(|b| b.h1.cov).collect();
+    let h2_cov: Vec<f32> = buckets.iter().map(|b| b.h2.cov).collect();
+    let out_cov: Vec<f32> = buckets.iter().map(|b| b.output.cov).collect();
+    writeln!(out, "  CoV (std / mean |W|):")?;
+    summary_row(out, "hidden1", &h1_cov, "", 2)?;
+    summary_row(out, "hidden2", &h2_cov, "", 2)?;
+    summary_row(out, "output", &out_cov, "", 2)?;
+    writeln!(out)?;
+
+    let h1_rel: Vec<f32> = buckets
+        .iter()
+        .map(|b| b.h1.rel_to_ref.unwrap_or(0.0))
+        .collect();
+    let h2_rel: Vec<f32> = buckets
+        .iter()
+        .map(|b| b.h2.rel_to_ref.unwrap_or(0.0))
+        .collect();
+    writeln!(out, "  rel (x bucket output mean |W|):")?;
+    summary_row(out, "hidden1", &h1_rel, "x", 2)?;
+    summary_row(out, "hidden2", &h2_rel, "x", 2)?;
+
+    Ok(())
+}
+
+fn summary_row(
+    out: &mut String,
+    label: &str,
+    values: &[f32],
+    suffix: &str,
+    decimals: usize,
+) -> fmt::Result {
+    writeln!(
+        out,
+        "    {label:7}: avg {:.*}{suffix} (range {:.*}{suffix} - {:.*}{suffix})",
+        decimals,
+        mean(values),
+        decimals,
+        min_of(values),
+        decimals,
+        max_of(values),
+    )
+}
+
+// Upper-triangle cosine similarity between each bucket's output weight vector.
+// Diagonal is always 1.00 and the matrix is symmetric, so we skip both.
+fn write_bucket_similarity(
+    out: &mut String,
+    buckets: &[OutputStack; OUTPUT_BUCKETS],
+) -> Result<(), Box<dyn Error>> {
+    let mut weights: Vec<Vec<f32>> = Vec::with_capacity(OUTPUT_BUCKETS);
+    for b in buckets {
+        weights.push(b.output.weight().flatten_all()?.to_vec1::<f32>()?);
+    }
+
+    write_header(out, "bucket output similarity (cosine)")?;
+    write!(out, "     ")?;
+    for j in 1..OUTPUT_BUCKETS {
+        write!(out, "{:>6}", format!("b{j}"))?;
+    }
+    writeln!(out)?;
+
+    for i in 0..OUTPUT_BUCKETS - 1 {
+        write!(out, "  b{i} ")?;
+        for j in 1..OUTPUT_BUCKETS {
+            if j <= i {
+                write!(out, "      ")?;
+            } else {
+                write!(out, "{:>6.2}", cosine(&weights[i], &weights[j]))?;
+            }
+        }
+        writeln!(out)?;
+    }
+    Ok(())
+}

--- a/nnue/src/bin/analysis/stats.rs
+++ b/nnue/src/bin/analysis/stats.rs
@@ -1,0 +1,171 @@
+use candle_nn::Linear;
+use cozy_chess::{Color, Piece};
+use nnue::encoding::{
+    BLACK_SPACE_END, BLACK_SUPPORT_END, BLACK_THREATS_END, NUM_FEATURES, PIECE_FEATURES_END,
+    PIECE_FEATURES_START, SIDE_TO_MOVE_IDX, WHITE_SPACE_START, WHITE_SUPPORT_START,
+    WHITE_THREATS_START,
+};
+use nnue::network::model::OutputStack;
+use std::error::Error;
+
+use crate::math;
+
+/// Weights with |w| below this are considered dead.
+pub const DEAD_WEIGHT_THRESHOLD: f32 = 1e-4;
+
+/// Output neurons whose row L2 norm exceeds this are considered active.
+pub const ACTIVE_NEURON_THRESHOLD: f32 = 1.0;
+
+/// Piece slots per square: 6 white + 6 black, in (P, N, B, R, Q, K) order.
+/// Matches the layout used by `encoding::piece_color_to_index`.
+pub const PIECES_PER_SQUARE: usize = Piece::NUM * Color::NUM;
+
+/// Feature group in the input layer. Used to split up column norms.
+pub struct FeatureGroup {
+    pub name: &'static str,
+    pub start: usize,
+    pub end: usize,
+}
+
+impl FeatureGroup {
+    pub fn len(&self) -> usize {
+        self.end - self.start
+    }
+}
+
+pub const FEATURE_GROUPS: &[FeatureGroup] = &[
+    FeatureGroup {
+        name: "pieces",
+        start: PIECE_FEATURES_START,
+        end: PIECE_FEATURES_END,
+    },
+    FeatureGroup {
+        name: "support",
+        start: WHITE_SUPPORT_START,
+        end: BLACK_SUPPORT_END,
+    },
+    FeatureGroup {
+        name: "space",
+        start: WHITE_SPACE_START,
+        end: BLACK_SPACE_END,
+    },
+    FeatureGroup {
+        name: "threats",
+        start: WHITE_THREATS_START,
+        end: BLACK_THREATS_END,
+    },
+    FeatureGroup {
+        name: "stm",
+        start: SIDE_TO_MOVE_IDX,
+        end: NUM_FEATURES,
+    },
+];
+
+/// Per-piece-type offsets inside the 12-slot piece block of a square.
+/// Each row is (name, white_offset, black_offset).
+pub const PIECE_TYPES: &[(&str, usize, usize)] = &[
+    ("pawn", 0, 6),
+    ("knight", 1, 7),
+    ("bishop", 2, 8),
+    ("rook", 3, 9),
+    ("queen", 4, 10),
+    ("king", 5, 11),
+];
+
+/// Aggregate statistics for a single linear layer.
+pub struct LayerStats {
+    pub weight_mean_abs: f32,
+    pub weight_median_abs: f32,
+    pub weight_std: f32,
+    pub weight_max_abs: f32,
+    pub bias_mean_signed: f32,
+    pub bias_mean_abs: f32,
+    pub bias_max_abs: f32,
+    /// mean|W| normalized by the Kaiming-uniform init scale (1.00x = unchanged from init).
+    pub scale: f32,
+    /// std / mean|W|: scale-invariant distribution shape.
+    pub cov: f32,
+    /// Fraction of weights with |W| below DEAD_WEIGHT_THRESHOLD.
+    pub dead_fraction: f32,
+    /// mean|W| relative to a reference mean. None for the embedding.
+    pub rel_to_ref: Option<f32>,
+    pub row_norm_min: f32,
+    pub row_norm_mean: f32,
+    pub row_norm_max: f32,
+    pub active_neurons: usize,
+    pub total_neurons: usize,
+}
+
+impl LayerStats {
+    pub fn from_linear(linear: &Linear) -> Result<Self, Box<dyn Error>> {
+        let weights = linear.weight().flatten_all()?.to_vec1::<f32>()?;
+        let biases = linear.bias().unwrap().to_vec1::<f32>()?;
+        let fan_in = linear.weight().dim(1)?;
+
+        let weight_mean_abs = math::mean_abs(&weights);
+        let weight_std = math::std_dev(&weights);
+        // Kaiming uniform draws from U(-1/sqrt(fan_in), 1/sqrt(fan_in)),
+        // so E[|W|] at init is 1/(2*sqrt(fan_in)). Scale is mean|W| / E[|W|_init].
+        let scale = weight_mean_abs * 2.0 * (fan_in as f32).sqrt();
+        let cov = if weight_mean_abs > 0.0 {
+            weight_std / weight_mean_abs
+        } else {
+            0.0
+        };
+        let dead_fraction = weights
+            .iter()
+            .filter(|w| w.abs() < DEAD_WEIGHT_THRESHOLD)
+            .count() as f32
+            / weights.len() as f32;
+
+        let norms = math::row_norms(&weights, fan_in);
+        let active_neurons = norms
+            .iter()
+            .filter(|&&n| n > ACTIVE_NEURON_THRESHOLD)
+            .count();
+
+        Ok(Self {
+            weight_mean_abs,
+            weight_median_abs: math::median_abs(&weights),
+            weight_std,
+            weight_max_abs: math::max_abs(&weights),
+            bias_mean_signed: math::mean(&biases),
+            bias_mean_abs: math::mean_abs(&biases),
+            bias_max_abs: math::max_abs(&biases),
+            scale,
+            cov,
+            dead_fraction,
+            rel_to_ref: None,
+            row_norm_min: math::min_of(&norms),
+            row_norm_mean: math::mean(&norms),
+            row_norm_max: math::max_of(&norms),
+            active_neurons,
+            total_neurons: norms.len(),
+        })
+    }
+}
+
+/// Stats for every refinement layer in one bucket.
+pub struct BucketStats {
+    pub h1: LayerStats,
+    pub h2: LayerStats,
+    pub output: LayerStats,
+}
+
+impl BucketStats {
+    pub fn from_stack(stack: &OutputStack) -> Result<Self, Box<dyn Error>> {
+        let mut h1 = LayerStats::from_linear(&stack.hidden1)?;
+        let mut h2 = LayerStats::from_linear(&stack.hidden2)?;
+        let mut output = LayerStats::from_linear(&stack.output)?;
+
+        // Refinement layers report mean|W| relative to their bucket's output mean|W|.
+        let ref_mean = output.weight_mean_abs;
+        if ref_mean > 0.0 {
+            h1.rel_to_ref = Some(h1.weight_mean_abs / ref_mean);
+            h2.rel_to_ref = Some(h2.weight_mean_abs / ref_mean);
+            output.rel_to_ref = Some(1.0);
+        }
+
+        Ok(Self { h1, h2, output })
+    }
+}

--- a/nnue/src/encoding.rs
+++ b/nnue/src/encoding.rs
@@ -35,21 +35,22 @@ pub const NUM_FEATURES: usize = NUM_PIECE_PLACEMENT_FEATURES
     + NUM_THREAT_FEATURES
     + NUM_SIDE_TO_MOVE_FEATURES; // 1153 total
 
-const PIECE_FEATURES_END: usize = NUM_PIECE_PLACEMENT_FEATURES;
-const WHITE_SUPPORT_START: usize = PIECE_FEATURES_END;
-const WHITE_SUPPORT_END: usize = WHITE_SUPPORT_START + Square::NUM;
-const BLACK_SUPPORT_START: usize = WHITE_SUPPORT_END;
-const BLACK_SUPPORT_END: usize = BLACK_SUPPORT_START + Square::NUM;
-const WHITE_SPACE_START: usize = BLACK_SUPPORT_END;
-const WHITE_SPACE_END: usize = WHITE_SPACE_START + Square::NUM;
-const BLACK_SPACE_START: usize = WHITE_SPACE_END;
-const BLACK_SPACE_END: usize = BLACK_SPACE_START + Square::NUM;
-const WHITE_THREATS_START: usize = BLACK_SPACE_END;
-const WHITE_THREATS_END: usize = WHITE_THREATS_START + Square::NUM;
-const BLACK_THREATS_START: usize = WHITE_THREATS_END;
-#[allow(dead_code)]
-const BLACK_THREATS_END: usize = BLACK_THREATS_START + Square::NUM;
-const SIDE_TO_MOVE_IDX: usize = NUM_FEATURES - 1;
+// Exported to the analysis tool
+pub const PIECE_FEATURES_START: usize = 0;
+pub const PIECE_FEATURES_END: usize = NUM_PIECE_PLACEMENT_FEATURES;
+pub const WHITE_SUPPORT_START: usize = PIECE_FEATURES_END;
+pub const WHITE_SUPPORT_END: usize = WHITE_SUPPORT_START + Square::NUM;
+pub const BLACK_SUPPORT_START: usize = WHITE_SUPPORT_END;
+pub const BLACK_SUPPORT_END: usize = BLACK_SUPPORT_START + Square::NUM;
+pub const WHITE_SPACE_START: usize = BLACK_SUPPORT_END;
+pub const WHITE_SPACE_END: usize = WHITE_SPACE_START + Square::NUM;
+pub const BLACK_SPACE_START: usize = WHITE_SPACE_END;
+pub const BLACK_SPACE_END: usize = BLACK_SPACE_START + Square::NUM;
+pub const WHITE_THREATS_START: usize = BLACK_SPACE_END;
+pub const WHITE_THREATS_END: usize = WHITE_THREATS_START + Square::NUM;
+pub const BLACK_THREATS_START: usize = WHITE_THREATS_END;
+pub const BLACK_THREATS_END: usize = BLACK_THREATS_START + Square::NUM;
+pub const SIDE_TO_MOVE_IDX: usize = NUM_FEATURES - 1;
 
 /// Encodes a board position into a dense f32 feature array.
 /// Used during training where f32 tensors are required.


### PR DESCRIPTION
Adds a small tool that dumps a weight analysis of the current NNUE to `nnue/model.analysis.txt`. I ended up using it a lot during training for eyeballing what the layers are actually doing. Which neurons are dead, how the buckets compare, what piece features the embedding cares about, etc.

Also checking the generated `model.analysis.txt` into the repo alongside the weights. It's deterministic from `model.safetensors`, so net updates now come with a readable diff of what the net actually learned.

Run with `make nnue-analysis`.