### PR TITLE
feat: dual-perspective accumulator

### DIFF
--- a/nnue/model.analysis.txt
+++ b/nnue/model.analysis.txt
@@ -1,232 +1,231 @@
-embedding (1153 -> 1024) ===========================================
-  weight:  mean 0.0607, median 0.0322, std 0.1042, max 1.9266, scale 4.12x, CoV 1.72, dead 3.1%
-  neurons: 1024/1024 active, row norm min 1.900 / mean 3.480 / max 10.028
-  bias:    mean -0.1778 (|b| mean 0.2086, max 0.6275)
+embedding (1152 -> 768) ============================================
+  weight:  mean 0.0514, median 0.0260, std 0.0900, max 1.2757, scale 3.49x, CoV 1.75, dead 3.2%
+  neurons: 768/768 active, row norm min 1.474 / mean 2.988 / max 11.302
+  bias:    mean -0.1643 (|b| mean 0.1901, max 0.5030)
 
   feature groups (column norms, x pieces):
-    pieces   ( 768 feats): norm 3.7408 (1.00x)
-    support  ( 128 feats): norm 1.3696 (0.37x)
-    space    ( 128 feats): norm 1.1618 (0.31x)
-    threats  ( 128 feats): norm 3.0615 (0.82x)
-    stm      (   1 feats): norm 6.5473 (1.75x)
+    pieces   ( 768 feats): norm 2.7996 (1.00x)
+    support  ( 128 feats): norm 1.0807 (0.39x)
+    space    ( 128 feats): norm 0.8342 (0.30x)
+    threats  ( 128 feats): norm 2.2957 (0.82x)
 
   piece types (column norms, x pawn):
-    pawn   (128 feats): norm 2.9953 (1.00x)
-    knight (128 feats): norm 3.3467 (1.12x)
-    bishop (128 feats): norm 3.5546 (1.19x)
-    rook   (128 feats): norm 3.4258 (1.14x)
-    queen  (128 feats): norm 4.1350 (1.38x)
-    king   (128 feats): norm 4.9875 (1.67x)
+    pawn   (128 feats): norm 2.2230 (1.00x)
+    knight (128 feats): norm 2.5107 (1.13x)
+    bishop (128 feats): norm 2.6156 (1.18x)
+    rook   (128 feats): norm 2.5157 (1.13x)
+    queen  (128 feats): norm 3.1370 (1.41x)
+    king   (128 feats): norm 3.7953 (1.71x)
 
-piece heatmaps (col norm per square, white | black) ================
-  pawn   white (0.000 - 5.053)     black (0.000 - 4.741)
+piece heatmaps (col norm per square, us | them) ====================
+  pawn   us (0.000 - 3.402)        them (0.000 - 3.649)
       a  b  c  d  e  f  g  h       a  b  c  d  e  f  g  h
     8                            8                        
-    7 ██ ██ ██ ██ ██ ██ ██ ██    7 ▓▓ ██ ▓▓ ▓▓ ▓▓ ██ ██ ▓▓
-    6 ▓▓ ▓▓ ▓▓ ▓▓ ██ ██ ██ ██    6 ▓▓ ▓▓ ██ ██ ██ ██ ██ ▓▓
-    5 ▓▓ ▓▓ ▓▓ ██ ██ ▓▓ ▓▓ ▓▓    5 ▓▓ ▓▓ ▓▓ ██ ██ ██ ██ ▓▓
-    4 ▓▓ ▓▓ ▓▓ ▓▓ ██ ▓▓ ▓▓ ▓▓    4 ▓▓ ▓▓ ▓▓ ██ ▓▓ ██ ▓▓ ██
-    3 ▓▓ ▓▓ ▓▓ ▓▓ ██ ▓▓ ██ ▓▓    3 ▓▓ ██ ██ ██ ██ ██ ██ ██
-    2 ▓▓ ▓▓ ▓▓ ▓▓ ▓▓ ██ ██ ▓▓    2 ██ ██ ██ ██ ██ ██ ██ ██
+    7 ██ ██ ██ ██ ██ ██ ██ ██    7 ▓▓ ██ ▓▓ ██ ▓▓ ██ ██ ██
+    6 ██ ▓▓ ██ ▓▓ ██ ██ ██ ██    6 ▓▓ ██ ██ ██ ██ ██ ▓▓ ▓▓
+    5 ▓▓ ██ ██ ██ ██ ██ ██ ▓▓    5 ▓▓ ▓▓ ██ ██ ██ ██ ██ ▓▓
+    4 ▓▓ ▓▓ ██ ██ ██ ██ ▓▓ ▓▓    4 ▓▓ ▓▓ ▓▓ ██ ██ ▓▓ ██ ▓▓
+    3 ▓▓ ▓▓ ██ ██ ██ ██ ██ ▓▓    3 ▓▓ ██ ▓▓ ██ ██ ██ ██ ██
+    2 ▓▓ ██ ██ ▓▓ ██ ██ ██ ▓▓    2 ██ ██ ██ ██ ██ ██ ██ ██
     1                            1                        
 
-  knight white (2.952 - 3.903)     black (2.982 - 3.716)
+  knight us (2.165 - 2.868)        them (2.190 - 2.987)
       a  b  c  d  e  f  g  h       a  b  c  d  e  f  g  h
-    8 ▓▓ ▒▒ ▒▒ ▓▓ ▓▓ ██ ██ ██    8 ██ ▓▓ ░░    ░░ ░░ ▒▒ ▓▓
-    7 ▓▓ ▒▒ ▓▓ ██ ▓▓ ██ ▒▒ ██    7 ▒▒ ░░    ░░ ░░         
-    6 ▒▒ ░░ ▒▒ ▒▒ ▓▓ ▒▒ ▒▒ ▓▓    6       ░░    ░░         
-    5 ░░ ░░ ░░ ▒▒ ░░ ▒▒ ▓▓ ▒▒    5 ░░       ░░ ░░ ▒▒ ░░ ░░
-    4 ░░    ▒▒ ░░ ▓▓ ▒▒ ▒▒ ▒▒    4 ░░ ░░ ░░ ▒▒ ░░ ▒▒ ▓▓ ░░
-    3 ░░ ░░ ▒▒    ░░ ▒▒ ░░ ░░    3 ░░    ▒▒ ░░ ▒▒ ▓▓ ░░ ▓▓
-    2 ░░ ▒▒    ░░ ░░    ░░ ▒▒    2 ░░ ░░ ▒▒ ▒▒ ██ ▒▒ ▒▒ ▓▓
-    1 ▓▓ ▓▓       ░░ ░░ ▒▒ ██    1 ██ ░░ ▓▓ ▒▒ ▒▒ ██ ██ ██
+    8 ▒▒ ▒▒ ▒▒ ▓▓ ▒▒ ██ ██ ▓▓    8 ▓▓ ▓▓ ░░       ░░ ▒▒ ▓▓
+    7 ▒▒ ▒▒ ▓▓ ░░ ▓▓ ▓▓ ▒▒ ██    7 ░░       ░░ ░░ ░░    ░░
+    6 ▒▒ ░░ ▓▓ ▓▓ ▒▒ ▓▓ ▒▒ ▓▓    6 ░░ ░░ ▒▒ ░░ ▓▓    ░░   
+    5    ░░ ▒▒ ░░ ▒▒ ▓▓ ▓▓ ▒▒    5 ▓▓ ░░ ██ ░░ ▓▓ ▒▒ ░░ ░░
+    4       ▒▒ ▒▒ ░░ ░░ ▒▒ ▓▓    4 ░░    ▒▒ ▓▓ ░░ ░░ ▒▒ ▒▒
+    3    ░░    ░░ ░░ ▒▒ ░░ ░░    3 ▒▒ ░░       ░░ ▒▒ ░░ ██
+    2 ░░    ░░ ▒▒ ▒▒ ▒▒ ░░ ▒▒    2 ░░ ▒▒ ▓▓ ▒▒ ▒▒ ▒▒ ▒▒ ▓▓
+    1 ██ ░░ ░░ ▒▒ ▒▒ ░░ ██ ██    1 ▓▓ ▓▓ ▒▒    ▒▒ ▒▒ ▓▓ ██
 
-  bishop white (3.124 - 4.269)     black (3.162 - 4.210)
+  bishop us (2.273 - 3.145)        them (2.350 - 3.190)
       a  b  c  d  e  f  g  h       a  b  c  d  e  f  g  h
-    8 ▒▒ ░░ ░░ ░░ ░░ ▒▒ ▓▓ ▒▒    8 ██ ▓▓ ▒▒ ░░    ▒▒ ▓▓ ██
-    7 ▒▒ ░░    ░░ ▒▒ ▒▒ ░░ ▒▒    7 ▓▓ ▒▒ ░░    ░░ ░░ ▒▒ ▒▒
-    6 ░░    ░░ ▒▒ ▒▒ ░░ ░░ ▒▒    6 ▒▒ ▒▒ ░░    ░░ ░░ ▒▒ ░░
-    5       ░░ ▒▒ ▒▒ ░░ ░░ ░░    5 ░░    ░░ ░░ ░░ ▒▒ ▒▒   
-    4 ░░ ░░ ░░ ░░ ▒▒ ▒▒ ░░ ░░    4       ░░ ▒▒ ▒▒ ░░ ░░   
-    3 ░░ ▒▒ ░░ ▒▒ ░░ ░░ ▒▒ ░░    3          ▒▒ ░░ ░░ ░░ ░░
-    2 ▒▒ ▓▓ ░░ ░░ ░░ ░░ ▓▓ ▒▒    2 ▒▒       ░░ ░░ ░░ ░░ ▒▒
-    1 ▓▓ ▓▓ ▒▒ ░░ ░░ ░░ ▓▓ ██    1 ░░ ░░ ░░ ░░ ░░ ▒▒ ▒▒ ░░
+    8 ░░ ░░ ░░ ▒▒ ░░ ▒▒ ▒▒ ▒▒    8 ▒▒ ▓▓ ▓▓ ▒▒    ░░ ▓▓ ██
+    7 ▒▒ ░░ ░░ ░░ ▒▒ ░░ ▒▒ ▒▒    7 ▒▒    ▒▒ ░░ ░░    ░░ ░░
+    6          ░░ ░░ ▓▓ ▒▒ ▒▒    6    ▒▒ ░░ ▒▒ ░░ ░░ ░░ ░░
+    5       ░░ ░░ ░░ ░░    ░░    5       ▒▒ ░░ ▒▒ ▒▒ ░░   
+    4    ░░ ▒▒ ▒▒ ░░    ░░ ░░    4       ░░ ▒▒ ▓▓ ░░ ▒▒   
+    3    ░░ ░░ ░░    ▒▒ ▒▒ ▒▒    3       ░░ ░░ ▒▒    ▒▒ ░░
+    2 ▒▒ ░░    ░░ ▒▒ ░░ ▓▓ ▓▓    2 ▒▒    ░░ ░░    ▓▓ ░░ ▓▓
+    1 ▓▓ ▒▒    ░░ ░░ ▒▒ ▓▓ ██    1 ▒▒ ░░ ░░ ░░ ░░ ░░ ▒▒ ▒▒
 
-  rook   white (3.094 - 3.884)     black (3.089 - 3.988)
+  rook   us (2.237 - 3.113)        them (2.187 - 2.783)
       a  b  c  d  e  f  g  h       a  b  c  d  e  f  g  h
-    8 ▒▒ ▒▒ ▒▒ ▓▓ ▓▓ ██ ▓▓ ▓▓    8 ██ ▓▓    ░░ ░░    ▓▓ ██
-    7 ▒▒ ▒▒ ▓▓ ▒▒ ▒▒ ▓▓ ██ ██    7 ▒▒ ░░       ░░ ░░ ▒▒ ▒▒
-    6 ▓▓ ▒▒ ▒▒ ▒▒ ▒▒ ▒▒ ▓▓ ▒▒    6 ░░       ░░    ░░ ░░ ▒▒
-    5 ▒▒ ░░ ░░    ░░ ░░ ▒▒ ░░    5                   ░░ ░░
-    4                   ░░ ░░    4 ░░ ░░          ░░ ░░ ░░
-    3             ░░    ░░ ░░    3 ░░ ░░ ░░ ░░ ░░ ▒▒ ▒▒ ▒▒
-    2 ▒▒ ░░       ░░ ▒▒ ▒▒ ██    2 ▒▒ ░░ ░░ ▒▒ ▒▒ ▓▓ ▓▓ ▓▓
-    1 ██ ▒▒ ░░ ▒▒ ░░ ░░ ▓▓ ██    1 ░░ ▒▒ ░░ ▒▒ ▓▓ ▓▓ ██ ▒▒
+    8 ▒▒ ▒▒ ▒▒ ▒▒ ▒▒ ▓▓ ▓▓ ▓▓    8 ▒▒ ▓▓ ░░ ░░ ░░ ░░ ▓▓ ▓▓
+    7 ▒▒ ▒▒ ▒▒ ▒▒ ▓▓ ▒▒ ▓▓ ██    7 ▒▒ ▒▒    ░░    ░░ ▒▒ ▒▒
+    6 ░░ ░░ ░░ ▒▒ ░░ ▒▒ ▒▒ ▒▒    6    ░░ ░░    ░░    ░░   
+    5    ░░ ░░       ░░ ░░ ▒▒    5       ░░    ▒▒ ░░ ▒▒ ░░
+    4       ░░ ░░    ░░ ░░ ▒▒    4       ░░    ░░ ░░ ▒▒ ░░
+    3 ░░       ░░    ░░ ▓▓ ▒▒    3 ░░ ▒▒ ▒▒ ░░ ░░ ▒▒ ██ ██
+    2 ░░          ░░ ░░ ▒▒ ▒▒    2 ▒▒ ██ ▓▓ ▒▒ ██ ██ ██ ▓▓
+    1 ██ ░░ ░░ ▒▒ ░░ ▒▒ ▓▓ ▓▓    1 ▓▓ ▓▓ ▓▓ ▒▒ ▓▓ ▓▓ ██ ██
 
-  queen  white (3.895 - 4.934)     black (3.787 - 4.631)
+  queen  us (2.778 - 3.525)        them (2.871 - 3.656)
       a  b  c  d  e  f  g  h       a  b  c  d  e  f  g  h
-    8 ▒▒ ▒▒ ▒▒ ▒▒ ▓▓ ▓▓ ██ ██    8 ░░ ▒▒             ░░ ▓▓
-    7 ░░ ░░ ▒▒ ░░ ▒▒ ▒▒ ▓▓ ▓▓    7                      ░░
-    6       ░░ ░░ ░░ ▓▓ ▒▒ ▒▒    6    ░░ ░░          ░░ ▒▒
-    5          ░░ ░░ ░░ ░░ ░░    5                      ░░
-    4                ░░    ░░    4 ░░ ░░ ░░ ░░ ░░    ░░ ▒▒
-    3                      ░░    3 ░░ ░░ ░░ ▒▒ ▒▒ ▓▓ ▒▒ ▓▓
-    2       ░░          ░░ ░░    2 ▒▒ ▒▒ ▒▒ ░░ ▒▒ ▓▓ ▓▓ ██
-    1 ░░                   ▒▒    1 ▒▒ ▒▒ ▒▒ ▒▒ ▓▓ ██ ██ ██
+    8 ██ ░░ ▒▒ ▒▒ ▒▒ ▓▓ ██ ██    8       ░░ ░░       ░░ ▒▒
+    7 ▒▒ ░░ ▒▒ ▒▒ ▓▓ ▓▓ ▓▓ ██    7 ░░    ░░          ░░ ▒▒
+    6 ▒▒ ▒▒ ▒▒ ░░ ▓▓ ▓▓ ▓▓ ▓▓    6 ░░ ░░ ░░    ░░    ░░ ░░
+    5 ▒▒ ▒▒ ▒▒ ░░ ░░ ▒▒ ░░ ▒▒    5 ▒▒ ░░       ░░    ▒▒ ▒▒
+    4 ░░    ░░ ░░    ░░ ░░ ▒▒    4 ░░ ░░ ░░ ░░ ░░ ░░ ▒▒ ▒▒
+    3 ░░ ░░          ▒▒ ░░ ░░    3 ░░ ▒▒ ▒▒ ░░ ░░ ▒▒ ▓▓ ██
+    2 ▒▒          ░░ ░░ ░░ ▒▒    2 ▒▒ ▓▓ ▒▒ ░░ ▒▒ ▓▓ ██ ▓▓
+    1 ▒▒    ░░ ░░ ░░ ░░ ░░ ▓▓    1 ▓▓ ▒▒ ░░ ▒▒ ▓▓ ▓▓ ▓▓ ██
 
-  king   white (4.233 - 6.125)     black (4.339 - 6.290)
+  king   us (3.384 - 4.814)        them (3.188 - 4.565)
       a  b  c  d  e  f  g  h       a  b  c  d  e  f  g  h
-    8 ▒▒ ▒▒ ▒▒ ░░ ░░ ▒▒ ▒▒ ▒▒    8 ██ ██ ▓▓ ▒▒ ▒▒ ░░ ▒▒ ▓▓
-    7 ▒▒ ▒▒ ▒▒ ░░ ░░ ▒▒ ▒▒ ▓▓    7 ██ ▓▓ ▒▒ ░░ ░░    ░░ ▒▒
-    6 ▒▒ ▒▒ ░░ ░░    ▒▒ ▒▒ ▒▒    6 ▒▒ ▒▒ ▒▒             ░░
-    5 ▒▒ ▒▒ ░░       ░░ ░░ ░░    5 ░░ ░░                  
-    4 ▒▒ ░░                      4 ░░ ░░             ░░ ░░
-    3 ▓▓ ▒▒ ░░          ░░ ░░    3 ░░ ░░ ░░       ░░ ▒▒ ░░
-    2 ▓▓ ▓▓ ▒▒ ░░       ░░ ▒▒    2 ░░ ▒▒ ▒▒ ░░ ░░ ░░ ▒▒ ▒▒
-    1 ██ ██ ▓▓ ░░ ▒▒ ░░ ▒▒ ▓▓    1 ▒▒ ░░ ░░ ░░    ░░ ░░ ▒▒
+    8 ░░ ░░          ░░ ░░ ▒▒    8 ██ ██ ▓▓ ░░ ▒▒ ▒▒ ▒▒ ▒▒
+    7 ▒▒ ▒▒ ░░ ░░    ░░ ░░ ▒▒    7 ▓▓ ▓▓ ▒▒ ░░    ░░ ▒▒ ▒▒
+    6 ░░ ░░             ▒▒ ░░    6 ▓▓ ▒▒ ░░ ▒▒       ░░ ░░
+    5 ░░ ░░ ░░          ░░ ░░    5 ▒▒ ▒▒ ░░               
+    4    ░░ ░░ ░░          ░░    4 ▒▒ ▒▒             ░░ ░░
+    3 ▓▓ ▒▒ ▒▒ ░░       ░░ ▒▒    3 ▒▒ ▒▒ ░░ ░░ ░░    ▒▒ ░░
+    2 ▓▓ ▓▓ ▓▓ ▒▒ ░░ ░░ ░░ ▒▒    2 ▒▒ ▒▒ ▒▒ ░░ ░░ ▒▒ ▒▒ ░░
+    1 ██ ██ ▓▓ ▒▒ ▓▓ ░░ ▒▒ ▓▓    1 ▓▓ ▒▒ ▒▒    ░░ ░░ ░░ ▒▒
 
 bucket 0 ===========================================================
-  hidden1 (1024 -> 16):
-    weight:  mean 0.0622, median 0.0248, std 0.1218, max 2.4030, scale 3.98x, CoV 1.96, rel 0.04x, dead 31.4%
-    neurons: 11/16 active, row norm min 0.000 / mean 3.167 / max 7.091
-    bias:    mean +0.0205 (|b| mean 0.0425, max 0.1758)
+  hidden1 (1536 -> 16):
+    weight:  mean 0.0629, median 0.0319, std 0.1103, max 1.2148, scale 4.93x, CoV 1.75, rel 0.03x, dead 18.9%
+    neurons: 13/16 active, row norm min 0.000 / mean 3.799 / max 7.108
+    bias:    mean +0.0112 (|b| mean 0.0213, max 0.0614)
   hidden2 (16 -> 16):
-    weight:  mean 0.3457, median 0.1623, std 0.5824, max 2.6383, scale 2.77x, CoV 1.68, rel 0.20x, dead 31.2%
-    neurons: 16/16 active, row norm min 1.584 / mean 2.254 / max 3.523
-    bias:    mean +0.0166 (|b| mean 0.0829, max 0.1947)
+    weight:  mean 0.4754, median 0.2538, std 0.7261, max 2.9546, scale 3.80x, CoV 1.53, rel 0.25x, dead 18.8%
+    neurons: 16/16 active, row norm min 2.117 / mean 2.919 / max 4.205
+    bias:    mean +0.0378 (|b| mean 0.0724, max 0.1835)
   output (16 -> 1):
-    weight:  mean 1.7727, median 2.0197, std 2.1232, max 4.2513, scale 14.18x, CoV 1.20, rel 1.00x, dead 0.0%
-    neurons: 1/1 active, row norm min 8.593 / mean 8.593 / max 8.593
-    bias:    mean +0.0563 (|b| mean 0.0563, max 0.0563)
+    weight:  mean 1.8662, median 1.3051, std 2.0958, max 4.3170, scale 14.93x, CoV 1.12, rel 1.00x, dead 0.0%
+    neurons: 1/1 active, row norm min 8.916 / mean 8.916 / max 8.916
+    bias:    mean +0.2061 (|b| mean 0.2061, max 0.2061)
 
 bucket 1 ===========================================================
-  hidden1 (1024 -> 16):
-    weight:  mean 0.0490, median 0.0162, std 0.0995, max 1.5779, scale 3.14x, CoV 2.03, rel 0.03x, dead 31.4%
-    neurons: 11/16 active, row norm min 0.000 / mean 2.629 / max 4.334
-    bias:    mean +0.0187 (|b| mean 0.0234, max 0.1200)
+  hidden1 (1536 -> 16):
+    weight:  mean 0.0554, median 0.0290, std 0.0983, max 1.0751, scale 4.34x, CoV 1.77, rel 0.03x, dead 18.8%
+    neurons: 13/16 active, row norm min 0.000 / mean 3.434 / max 5.759
+    bias:    mean +0.0209 (|b| mean 0.0366, max 0.1143)
   hidden2 (16 -> 16):
-    weight:  mean 0.3030, median 0.1201, std 0.5821, max 2.7914, scale 2.42x, CoV 1.92, rel 0.20x, dead 31.2%
-    neurons: 16/16 active, row norm min 1.122 / mean 2.238 / max 3.716
-    bias:    mean +0.0454 (|b| mean 0.1000, max 0.3705)
+    weight:  mean 0.3257, median 0.1796, std 0.5526, max 4.5289, scale 2.61x, CoV 1.70, rel 0.19x, dead 18.8%
+    neurons: 15/16 active, row norm min 0.971 / mean 2.027 / max 5.314
+    bias:    mean +0.0282 (|b| mean 0.0825, max 0.1905)
   output (16 -> 1):
-    weight:  mean 1.5162, median 1.1658, std 1.7545, max 3.3996, scale 12.13x, CoV 1.16, rel 1.00x, dead 0.0%
-    neurons: 1/1 active, row norm min 7.057 / mean 7.057 / max 7.057
-    bias:    mean -0.0290 (|b| mean 0.0290, max 0.0290)
+    weight:  mean 1.7297, median 1.2861, std 1.9209, max 3.3089, scale 13.84x, CoV 1.11, rel 1.00x, dead 0.0%
+    neurons: 1/1 active, row norm min 7.725 / mean 7.725 / max 7.725
+    bias:    mean +0.0178 (|b| mean 0.0178, max 0.0178)
 
 bucket 2 ===========================================================
-  hidden1 (1024 -> 16):
-    weight:  mean 0.0608, median 0.0273, std 0.1141, max 1.1480, scale 3.89x, CoV 1.88, rel 0.04x, dead 19.1%
-    neurons: 13/16 active, row norm min 0.000 / mean 3.259 / max 5.419
-    bias:    mean +0.0209 (|b| mean 0.0393, max 0.1826)
+  hidden1 (1536 -> 16):
+    weight:  mean 0.0488, median 0.0191, std 0.0963, max 0.9644, scale 3.83x, CoV 1.97, rel 0.03x, dead 31.5%
+    neurons: 11/16 active, row norm min 0.000 / mean 3.099 / max 5.842
+    bias:    mean +0.0242 (|b| mean 0.0342, max 0.1630)
   hidden2 (16 -> 16):
-    weight:  mean 0.3019, median 0.1656, std 0.5402, max 3.3504, scale 2.42x, CoV 1.79, rel 0.20x, dead 18.8%
-    neurons: 16/16 active, row norm min 1.048 / mean 2.023 / max 3.546
-    bias:    mean -0.0069 (|b| mean 0.0985, max 0.3573)
+    weight:  mean 0.2905, median 0.1192, std 0.5171, max 3.0926, scale 2.32x, CoV 1.78, rel 0.16x, dead 31.2%
+    neurons: 16/16 active, row norm min 1.188 / mean 1.959 / max 3.468
+    bias:    mean +0.0241 (|b| mean 0.1026, max 0.3550)
   output (16 -> 1):
-    weight:  mean 1.5109, median 1.2723, std 1.7491, max 3.5156, scale 12.09x, CoV 1.16, rel 1.00x, dead 0.0%
-    neurons: 1/1 active, row norm min 7.061 / mean 7.061 / max 7.061
-    bias:    mean +0.0955 (|b| mean 0.0955, max 0.0955)
+    weight:  mean 1.7975, median 1.7864, std 1.9311, max 3.6786, scale 14.38x, CoV 1.07, rel 1.00x, dead 0.0%
+    neurons: 1/1 active, row norm min 8.198 / mean 8.198 / max 8.198
+    bias:    mean +0.1017 (|b| mean 0.1017, max 0.1017)
 
 bucket 3 ===========================================================
-  hidden1 (1024 -> 16):
-    weight:  mean 0.0485, median 0.0000, std 0.1286, max 1.5624, scale 3.11x, CoV 2.65, rel 0.03x, dead 56.5%
-    neurons: 7/16 active, row norm min 0.000 / mean 2.651 / max 8.428
-    bias:    mean +0.0349 (|b| mean 0.0414, max 0.2295)
+  hidden1 (1536 -> 16):
+    weight:  mean 0.0292, median 0.0000, std 0.0771, max 1.0417, scale 2.29x, CoV 2.65, rel 0.02x, dead 62.7%
+    neurons: 6/16 active, row norm min 0.000 / mean 1.819 / max 6.659
+    bias:    mean +0.0225 (|b| mean 0.0233, max 0.2382)
   hidden2 (16 -> 16):
-    weight:  mean 0.1360, median 0.0000, std 0.2901, max 1.4632, scale 1.09x, CoV 2.13, rel 0.08x, dead 59.0%
-    neurons: 10/16 active, row norm min 0.000 / mean 1.075 / max 1.800
-    bias:    mean -0.0164 (|b| mean 0.1164, max 0.3591)
+    weight:  mean 0.1358, median 0.0000, std 0.3377, max 3.3472, scale 1.09x, CoV 2.49, rel 0.10x, dead 67.2%
+    neurons: 9/16 active, row norm min 0.000 / mean 1.129 / max 3.450
+    bias:    mean +0.0266 (|b| mean 0.0864, max 0.2724)
   output (16 -> 1):
-    weight:  mean 1.6116, median 1.7937, std 1.8797, max 3.4995, scale 12.89x, CoV 1.17, rel 1.00x, dead 6.2%
-    neurons: 1/1 active, row norm min 7.520 / mean 7.520 / max 7.520
-    bias:    mean +0.1101 (|b| mean 0.1101, max 0.1101)
+    weight:  mean 1.4264, median 1.2427, std 1.6224, max 3.0722, scale 11.41x, CoV 1.14, rel 1.00x, dead 12.5%
+    neurons: 1/1 active, row norm min 6.668 / mean 6.668 / max 6.668
+    bias:    mean +0.0104 (|b| mean 0.0104, max 0.0104)
 
 bucket 4 ===========================================================
-  hidden1 (1024 -> 16):
-    weight:  mean 0.0473, median 0.0000, std 0.1278, max 2.1971, scale 3.03x, CoV 2.70, rel 0.04x, dead 56.7%
-    neurons: 7/16 active, row norm min 0.000 / mean 2.648 / max 7.571
-    bias:    mean +0.0474 (|b| mean 0.0474, max 0.3057)
+  hidden1 (1536 -> 16):
+    weight:  mean 0.0207, median 0.0000, std 0.0765, max 1.3187, scale 1.62x, CoV 3.70, rel 0.01x, dead 75.4%
+    neurons: 4/16 active, row norm min 0.000 / mean 1.416 / max 9.012
+    bias:    mean +0.0350 (|b| mean 0.0350, max 0.1951)
   hidden2 (16 -> 16):
-    weight:  mean 0.1227, median 0.0000, std 0.3034, max 3.0608, scale 0.98x, CoV 2.47, rel 0.10x, dead 61.7%
-    neurons: 4/16 active, row norm min 0.000 / mean 0.950 / max 3.500
-    bias:    mean -0.0202 (|b| mean 0.1344, max 0.6545)
+    weight:  mean 0.0847, median 0.0000, std 0.2103, max 1.4149, scale 0.68x, CoV 2.48, rel 0.05x, dead 75.0%
+    neurons: 3/16 active, row norm min 0.359 / mean 0.782 / max 1.634
+    bias:    mean -0.0703 (|b| mean 0.2022, max 0.4675)
   output (16 -> 1):
-    weight:  mean 1.2038, median 1.1580, std 1.3703, max 2.7625, scale 9.63x, CoV 1.14, rel 1.00x, dead 12.5%
-    neurons: 1/1 active, row norm min 5.708 / mean 5.708 / max 5.708
-    bias:    mean +0.0426 (|b| mean 0.0426, max 0.0426)
+    weight:  mean 1.7261, median 1.7789, std 1.8537, max 3.2139, scale 13.81x, CoV 1.07, rel 1.00x, dead 0.0%
+    neurons: 1/1 active, row norm min 7.417 / mean 7.417 / max 7.417
+    bias:    mean +0.2662 (|b| mean 0.2662, max 0.2662)
 
 bucket 5 ===========================================================
-  hidden1 (1024 -> 16):
-    weight:  mean 0.0196, median 0.0000, std 0.0894, max 2.1120, scale 1.25x, CoV 4.56, rel 0.01x, dead 81.6%
-    neurons: 3/16 active, row norm min 0.000 / mean 1.207 / max 8.488
-    bias:    mean +0.0238 (|b| mean 0.0238, max 0.2197)
+  hidden1 (1536 -> 16):
+    weight:  mean 0.0237, median 0.0000, std 0.0757, max 1.2017, scale 1.86x, CoV 3.19, rel 0.02x, dead 69.6%
+    neurons: 5/16 active, row norm min 0.000 / mean 1.589 / max 8.142
+    bias:    mean +0.0328 (|b| mean 0.0328, max 0.1796)
   hidden2 (16 -> 16):
-    weight:  mean 0.0836, median 0.0000, std 0.2878, max 3.0446, scale 0.67x, CoV 3.44, rel 0.05x, dead 82.4%
-    neurons: 3/16 active, row norm min 0.000 / mean 0.930 / max 3.079
-    bias:    mean -0.0191 (|b| mean 0.1766, max 0.5056)
+    weight:  mean 0.0936, median 0.0000, std 0.2191, max 1.2855, scale 0.75x, CoV 2.34, rel 0.07x, dead 68.8%
+    neurons: 3/16 active, row norm min 0.436 / mean 0.833 / max 1.591
+    bias:    mean -0.0732 (|b| mean 0.1249, max 0.3476)
   output (16 -> 1):
-    weight:  mean 1.7611, median 1.7490, std 1.9832, max 3.6113, scale 14.09x, CoV 1.13, rel 1.00x, dead 6.2%
-    neurons: 1/1 active, row norm min 7.957 / mean 7.957 / max 7.957
-    bias:    mean +0.1797 (|b| mean 0.1797, max 0.1797)
+    weight:  mean 1.3237, median 1.2675, std 1.4510, max 2.3698, scale 10.59x, CoV 1.10, rel 1.00x, dead 0.0%
+    neurons: 1/1 active, row norm min 5.804 / mean 5.804 / max 5.804
+    bias:    mean -0.0274 (|b| mean 0.0274, max 0.0274)
 
 bucket 6 ===========================================================
-  hidden1 (1024 -> 16):
-    weight:  mean 0.0418, median 0.0000, std 0.1156, max 1.5276, scale 2.68x, CoV 2.76, rel 0.04x, dead 63.6%
-    neurons: 6/16 active, row norm min 0.000 / mean 2.257 / max 7.142
-    bias:    mean +0.0477 (|b| mean 0.0477, max 0.2199)
+  hidden1 (1536 -> 16):
+    weight:  mean 0.0134, median 0.0000, std 0.0528, max 1.5287, scale 1.05x, CoV 3.93, rel 0.01x, dead 82.1%
+    neurons: 3/16 active, row norm min 0.000 / mean 0.888 / max 5.612
+    bias:    mean +0.0097 (|b| mean 0.0171, max 0.1566)
   hidden2 (16 -> 16):
-    weight:  mean 0.0972, median 0.0000, std 0.2340, max 1.2514, scale 0.78x, CoV 2.41, rel 0.09x, dead 71.9%
-    neurons: 6/16 active, row norm min 0.000 / mean 0.764 / max 1.635
-    bias:    mean -0.0594 (|b| mean 0.1194, max 0.4883)
+    weight:  mean 0.0720, median 0.0000, std 0.2363, max 1.4219, scale 0.58x, CoV 3.28, rel 0.07x, dead 85.9%
+    neurons: 5/16 active, row norm min 0.000 / mean 0.764 / max 1.940
+    bias:    mean -0.0227 (|b| mean 0.0888, max 0.2928)
   output (16 -> 1):
-    weight:  mean 1.0583, median 1.2691, std 1.3605, max 2.6908, scale 8.47x, CoV 1.29, rel 1.00x, dead 25.0%
-    neurons: 1/1 active, row norm min 5.453 / mean 5.453 / max 5.453
-    bias:    mean -0.1582 (|b| mean 0.1582, max 0.1582)
+    weight:  mean 1.0463, median 1.1881, std 1.2651, max 2.6073, scale 8.37x, CoV 1.21, rel 1.00x, dead 25.0%
+    neurons: 1/1 active, row norm min 5.131 / mean 5.131 / max 5.131
+    bias:    mean -0.0641 (|b| mean 0.0641, max 0.0641)
 
 bucket 7 ===========================================================
-  hidden1 (1024 -> 16):
-    weight:  mean 0.0145, median 0.0000, std 0.0689, max 2.4925, scale 0.93x, CoV 4.74, rel 0.02x, dead 88.3%
-    neurons: 2/16 active, row norm min 0.000 / mean 0.778 / max 6.665
-    bias:    mean +0.0058 (|b| mean 0.0058, max 0.0602)
+  hidden1 (1536 -> 16):
+    weight:  mean 0.0069, median 0.0000, std 0.0451, max 2.2461, scale 0.54x, CoV 6.52, rel 0.01x, dead 94.3%
+    neurons: 1/16 active, row norm min 0.000 / mean 0.442 / max 7.079
+    bias:    mean +0.0100 (|b| mean 0.0100, max 0.1604)
   hidden2 (16 -> 16):
-    weight:  mean 0.0391, median 0.0000, std 0.2446, max 3.2390, scale 0.31x, CoV 6.26, rel 0.05x, dead 93.0%
-    neurons: 4/16 active, row norm min 0.000 / mean 0.541 / max 3.263
-    bias:    mean +0.0132 (|b| mean 0.0643, max 0.1975)
+    weight:  mean 0.0203, median 0.0000, std 0.1964, max 2.9705, scale 0.16x, CoV 9.69, rel 0.02x, dead 97.7%
+    neurons: 1/16 active, row norm min 0.000 / mean 0.324 / max 2.971
+    bias:    mean -0.0226 (|b| mean 0.0935, max 0.5216)
   output (16 -> 1):
-    weight:  mean 0.8304, median 0.6760, std 1.2641, max 2.7141, scale 6.64x, CoV 1.52, rel 1.00x, dead 43.8%
-    neurons: 1/1 active, row norm min 5.085 / mean 5.085 / max 5.085
-    bias:    mean +0.0775 (|b| mean 0.0775, max 0.0775)
+    weight:  mean 0.8875, median 0.0000, std 1.5585, max 3.9994, scale 7.10x, CoV 1.76, rel 1.00x, dead 62.5%
+    neurons: 1/1 active, row norm min 6.260 / mean 6.260 / max 6.260
+    bias:    mean +0.1160 (|b| mean 0.1160, max 0.1160)
 
 summary (across 8 buckets) =========================================
   scale (x init):
-    hidden1: avg 2.75x (range 0.93x - 3.98x)
-    hidden2: avg 1.43x (range 0.31x - 2.77x)
-    output : avg 11.26x (range 6.64x - 14.18x)
+    hidden1: avg 2.56x (range 0.54x - 4.93x)
+    hidden2: avg 1.50x (range 0.16x - 3.80x)
+    output : avg 11.80x (range 7.10x - 14.93x)
 
   dead weight fraction:
-    hidden1: avg 53.6% (range 19.1% - 88.3%)
-    hidden2: avg 56.2% (range 18.8% - 93.0%)
-    output : avg 11.7% (range 0.0% - 43.8%)
+    hidden1: avg 56.7% (range 18.8% - 94.3%)
+    hidden2: avg 57.9% (range 18.8% - 97.7%)
+    output : avg 12.5% (range 0.0% - 62.5%)
 
   active neurons (of 16):
-    hidden1: avg 7.5 (range 2.0 - 13.0)
-    hidden2: avg 9.4 (range 3.0 - 16.0)
+    hidden1: avg 7.0 (range 1.0 - 13.0)
+    hidden2: avg 8.5 (range 1.0 - 16.0)
 
   CoV (std / mean |W|):
-    hidden1: avg 2.91 (range 1.88 - 4.74)
-    hidden2: avg 2.76 (range 1.68 - 6.26)
-    output : avg 1.22 (range 1.13 - 1.52)
+    hidden1: avg 3.19 (range 1.75 - 6.52)
+    hidden2: avg 3.16 (range 1.53 - 9.69)
+    output : avg 1.20 (range 1.07 - 1.76)
 
   rel (x bucket output mean |W|):
-    hidden1: avg 0.03x (range 0.01x - 0.04x)
-    hidden2: avg 0.12x (range 0.05x - 0.20x)
+    hidden1: avg 0.02x (range 0.01x - 0.03x)
+    hidden2: avg 0.11x (range 0.02x - 0.25x)
 
 bucket output similarity (cosine) ==================================
          b1    b2    b3    b4    b5    b6    b7
-  b0   0.15 -0.01 -0.12 -0.03  0.56  0.11 -0.45
-  b1         0.05  0.10 -0.28  0.28 -0.36 -0.05
-  b2               0.20 -0.35  0.29 -0.69 -0.34
-  b3                     0.05  0.31 -0.08 -0.20
-  b4                          -0.45  0.13  0.16
-  b5                                 0.02 -0.28
-  b6                                       0.13
+  b0   0.02  0.28 -0.23  0.42  0.11 -0.35  0.17
+  b1        -0.09 -0.26 -0.23 -0.06  0.21 -0.16
+  b2              -0.18 -0.06  0.11  0.07 -0.14
+  b3                    -0.34  0.34  0.10  0.16
+  b4                           0.09 -0.24  0.04
+  b5                                -0.02  0.01
+  b6                                       0.06

--- a/nnue/model.safetensors
+++ b/nnue/model.safetensors
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9e5b6b7c1ef16b2fbd51f7105667b0eadd0298030914db43b4c814f9e41058d3
-size 5265120
+oid sha256:fe37ed2eb0ac76b4949336de8a32b7462b19289c7e0b82decaf73827f564e6bd
+size 4342496

--- a/nnue/src/bin/analysis/report.rs
+++ b/nnue/src/bin/analysis/report.rs
@@ -61,12 +61,12 @@ fn write_embedding(out: &mut String, embedding: &Linear) -> Result<(), Box<dyn E
     }
     writeln!(out)?;
 
-    // Piece-type means combine both colors so the number reads as total weight
+    // Piece-type means combine us and them so the number reads as total weight
     // the net gives to e.g. all knights across the board.
     writeln!(out, "  piece types (column norms, x pawn):")?;
     let pawn_mean = piece_type_mean(&norms, PIECE_TYPES[0].1, PIECE_TYPES[0].2);
-    for &(name, white_off, black_off) in PIECE_TYPES {
-        let m = piece_type_mean(&norms, white_off, black_off);
+    for &(name, us_off, them_off) in PIECE_TYPES {
+        let m = piece_type_mean(&norms, us_off, them_off);
         writeln!(
             out,
             "    {:6} ({:3} feats): norm {:.4} ({:.2}x)",
@@ -80,42 +80,43 @@ fn write_embedding(out: &mut String, embedding: &Linear) -> Result<(), Box<dyn E
     Ok(())
 }
 
-fn piece_type_mean(col_norms: &[f32], white_off: usize, black_off: usize) -> f32 {
+fn piece_type_mean(col_norms: &[f32], us_off: usize, them_off: usize) -> f32 {
     let mut sum = 0.0;
     for sq in 0..Square::NUM {
-        sum += col_norms[sq * PIECES_PER_SQUARE + white_off];
-        sum += col_norms[sq * PIECES_PER_SQUARE + black_off];
+        sum += col_norms[sq * PIECES_PER_SQUARE + us_off];
+        sum += col_norms[sq * PIECES_PER_SQUARE + them_off];
     }
     sum / (Square::NUM * 2) as f32
 }
 
-// Side-by-side 8x8 heatmaps per piece type, white on the left, black on the right.
-// Each side is normalized against its own range so any color asymmetry is obvious.
-// Relevant since the embedding treats white and black as fully independent features.
+// Side-by-side 8x8 heatmaps per piece type from the perspective the embedding
+// sees: "us" on the left, "them" on the right. Each side is normalized against
+// its own range so any us/them asymmetry is obvious. Squares are oriented from
+// the perspective viewer's side, so rank 1 is the back rank for us.
 fn write_piece_heatmaps(out: &mut String, embedding: &Linear) -> Result<(), Box<dyn Error>> {
     let weights = embedding.weight().flatten_all()?.to_vec1::<f32>()?;
     let fan_in = embedding.weight().dim(1)?;
     let norms = col_norms(&weights, fan_in);
 
-    write_header(out, "piece heatmaps (col norm per square, white | black)")?;
-    for &(name, white_off, black_off) in PIECE_TYPES {
-        let white = per_square_norms(&norms, white_off);
-        let black = per_square_norms(&norms, black_off);
-        let (wmin, wmax) = (min_of(&white), max_of(&white));
-        let (bmin, bmax) = (min_of(&black), max_of(&black));
+    write_header(out, "piece heatmaps (col norm per square, us | them)")?;
+    for &(name, us_off, them_off) in PIECE_TYPES {
+        let us = per_square_norms(&norms, us_off);
+        let them = per_square_norms(&norms, them_off);
+        let (umin, umax) = (min_of(&us), max_of(&us));
+        let (tmin, tmax) = (min_of(&them), max_of(&them));
 
         writeln!(
             out,
-            "  {name:6} white ({wmin:.3} - {wmax:.3})     black ({bmin:.3} - {bmax:.3})",
+            "  {name:6} us ({umin:.3} - {umax:.3})        them ({tmin:.3} - {tmax:.3})",
         )?;
         writeln!(
             out,
             "      a  b  c  d  e  f  g  h       a  b  c  d  e  f  g  h"
         )?;
         for rank in (0..8).rev() {
-            write_rank(out, "    ", rank, &white, wmin, wmax)?;
+            write_rank(out, "    ", rank, &us, umin, umax)?;
             write!(out, "    ")?;
-            write_rank(out, "", rank, &black, bmin, bmax)?;
+            write_rank(out, "", rank, &them, tmin, tmax)?;
             writeln!(out)?;
         }
         writeln!(out)?;
@@ -162,7 +163,7 @@ fn write_buckets(
         let stats = BucketStats::from_stack(stack)?;
 
         write_header(out, &format!("bucket {i}"))?;
-        writeln!(out, "  hidden1 ({EMBEDDING_SIZE} -> {HIDDEN_SIZE}):")?;
+        writeln!(out, "  hidden1 ({} -> {HIDDEN_SIZE}):", 2 * EMBEDDING_SIZE)?;
         write_layer(out, &stats.h1, "    ")?;
         writeln!(out, "  hidden2 ({HIDDEN_SIZE} -> {HIDDEN_SIZE}):")?;
         write_layer(out, &stats.h2, "    ")?;

--- a/nnue/src/bin/analysis/stats.rs
+++ b/nnue/src/bin/analysis/stats.rs
@@ -1,9 +1,8 @@
 use candle_nn::Linear;
 use cozy_chess::{Color, Piece};
 use nnue::encoding::{
-    BLACK_SPACE_END, BLACK_SUPPORT_END, BLACK_THREATS_END, NUM_FEATURES, PIECE_FEATURES_END,
-    PIECE_FEATURES_START, SIDE_TO_MOVE_IDX, WHITE_SPACE_START, WHITE_SUPPORT_START,
-    WHITE_THREATS_START,
+    PIECE_FEATURES_END, PIECE_FEATURES_START, THEM_SPACE_END, THEM_SUPPORT_END, THEM_THREATS_END,
+    US_SPACE_START, US_SUPPORT_START, US_THREATS_START,
 };
 use nnue::network::model::OutputStack;
 use std::error::Error;
@@ -16,8 +15,8 @@ pub const DEAD_WEIGHT_THRESHOLD: f32 = 1e-4;
 /// Output neurons whose row L2 norm exceeds this are considered active.
 pub const ACTIVE_NEURON_THRESHOLD: f32 = 1.0;
 
-/// Piece slots per square: 6 white + 6 black, in (P, N, B, R, Q, K) order.
-/// Matches the layout used by `encoding::piece_color_to_index`.
+/// Piece slots per square: 6 us + 6 them, in (P, N, B, R, Q, K) order.
+/// Matches the layout used by `encoding::piece_index`.
 pub const PIECES_PER_SQUARE: usize = Piece::NUM * Color::NUM;
 
 /// Feature group in the input layer. Used to split up column norms.
@@ -41,28 +40,23 @@ pub const FEATURE_GROUPS: &[FeatureGroup] = &[
     },
     FeatureGroup {
         name: "support",
-        start: WHITE_SUPPORT_START,
-        end: BLACK_SUPPORT_END,
+        start: US_SUPPORT_START,
+        end: THEM_SUPPORT_END,
     },
     FeatureGroup {
         name: "space",
-        start: WHITE_SPACE_START,
-        end: BLACK_SPACE_END,
+        start: US_SPACE_START,
+        end: THEM_SPACE_END,
     },
     FeatureGroup {
         name: "threats",
-        start: WHITE_THREATS_START,
-        end: BLACK_THREATS_END,
-    },
-    FeatureGroup {
-        name: "stm",
-        start: SIDE_TO_MOVE_IDX,
-        end: NUM_FEATURES,
+        start: US_THREATS_START,
+        end: THEM_THREATS_END,
     },
 ];
 
 /// Per-piece-type offsets inside the 12-slot piece block of a square.
-/// Each row is (name, white_offset, black_offset).
+/// Each row is (name, us_offset, them_offset).
 pub const PIECE_TYPES: &[(&str, usize, usize)] = &[
     ("pawn", 0, 6),
     ("knight", 1, 7),

--- a/nnue/src/encoding.rs
+++ b/nnue/src/encoding.rs
@@ -1,58 +1,31 @@
 use cozy_chess::{BitBoard, Board, Color, Piece, Square};
 use utils::bitset::Bitset;
 
-// Feature Layout (1153 total):
-//
-// Piece Placements [0-767]:
-//   Per square (12 features): [WP, WN, WB, WR, WQ, WK, BP, BN, BB, BR, BQ, BK]
-//
-//   [Sq0 (A1)][Sq1 (B1)]...[Sq63 (H8)]
-//   └─ 12 ──┘ └─ 12 ──┘    └── 12 ──┘
-//
-// Support [768-895] - squares where color defends own pieces:
-//   [White: Sq0...Sq63][Black: Sq0...Sq63]
-//   └────── 64 ───────┘└────── 64 ───────┘
-//
-// Space [896-1023] - squares color controls (excl. own pieces):
-//   [White: Sq0...Sq63][Black: Sq0...Sq63]
-//   └────── 64 ───────┘└────── 64 ───────┘
-//
-// Threats [1024-1151] - squares of valuable pieces attacked by lesser pieces:
-//   [White: Sq0...Sq63][Black: Sq0...Sq63]
-//   └────── 64 ───────┘└────── 64 ───────┘
-//
-// Side to Move [1152] - 1.0 if White to move
-
 const NUM_PIECE_PLACEMENT_FEATURES: usize = Square::NUM * Piece::NUM * Color::NUM;
 const NUM_SUPPORT_FEATURES: usize = Square::NUM * 2;
 const NUM_SPACE_FEATURES: usize = Square::NUM * 2;
 const NUM_THREAT_FEATURES: usize = Square::NUM * 2;
-const NUM_SIDE_TO_MOVE_FEATURES: usize = 1;
 
-pub const NUM_FEATURES: usize = NUM_PIECE_PLACEMENT_FEATURES
-    + NUM_SUPPORT_FEATURES
-    + NUM_SPACE_FEATURES
-    + NUM_THREAT_FEATURES
-    + NUM_SIDE_TO_MOVE_FEATURES; // 1153 total
+pub const NUM_FEATURES: usize =
+    NUM_PIECE_PLACEMENT_FEATURES + NUM_SUPPORT_FEATURES + NUM_SPACE_FEATURES + NUM_THREAT_FEATURES; // 1152 total
 
 // Exported to the analysis tool
 pub const PIECE_FEATURES_START: usize = 0;
 pub const PIECE_FEATURES_END: usize = NUM_PIECE_PLACEMENT_FEATURES;
-pub const WHITE_SUPPORT_START: usize = PIECE_FEATURES_END;
-pub const WHITE_SUPPORT_END: usize = WHITE_SUPPORT_START + Square::NUM;
-pub const BLACK_SUPPORT_START: usize = WHITE_SUPPORT_END;
-pub const BLACK_SUPPORT_END: usize = BLACK_SUPPORT_START + Square::NUM;
-pub const WHITE_SPACE_START: usize = BLACK_SUPPORT_END;
-pub const WHITE_SPACE_END: usize = WHITE_SPACE_START + Square::NUM;
-pub const BLACK_SPACE_START: usize = WHITE_SPACE_END;
-pub const BLACK_SPACE_END: usize = BLACK_SPACE_START + Square::NUM;
-pub const WHITE_THREATS_START: usize = BLACK_SPACE_END;
-pub const WHITE_THREATS_END: usize = WHITE_THREATS_START + Square::NUM;
-pub const BLACK_THREATS_START: usize = WHITE_THREATS_END;
-pub const BLACK_THREATS_END: usize = BLACK_THREATS_START + Square::NUM;
-pub const SIDE_TO_MOVE_IDX: usize = NUM_FEATURES - 1;
+pub const US_SUPPORT_START: usize = PIECE_FEATURES_END;
+pub const US_SUPPORT_END: usize = US_SUPPORT_START + Square::NUM;
+pub const THEM_SUPPORT_START: usize = US_SUPPORT_END;
+pub const THEM_SUPPORT_END: usize = THEM_SUPPORT_START + Square::NUM;
+pub const US_SPACE_START: usize = THEM_SUPPORT_END;
+pub const US_SPACE_END: usize = US_SPACE_START + Square::NUM;
+pub const THEM_SPACE_START: usize = US_SPACE_END;
+pub const THEM_SPACE_END: usize = THEM_SPACE_START + Square::NUM;
+pub const US_THREATS_START: usize = THEM_SPACE_END;
+pub const US_THREATS_END: usize = US_THREATS_START + Square::NUM;
+pub const THEM_THREATS_START: usize = US_THREATS_END;
+pub const THEM_THREATS_END: usize = THEM_THREATS_START + Square::NUM;
 
-/// Encodes a board position into a dense f32 feature array.
+/// Encodes a board position into a dense f32 feature array from a perspective.
 /// Used during training where f32 tensors are required.
 pub fn encode_board(
     board: &Board,
@@ -62,57 +35,51 @@ pub fn encode_board(
     black_support: BitBoard,
     white_threats: BitBoard,
     black_threats: BitBoard,
+    perspective: Color,
 ) -> [f32; NUM_FEATURES] {
     let mut features = [0f32; NUM_FEATURES];
 
     // Piece placements
     for color in [Color::White, Color::Black] {
+        let side_offset = if color == perspective { 0 } else { Piece::NUM };
         for piece in Piece::ALL {
-            let piece_idx = piece_color_to_index(piece, color);
+            let piece_idx = side_offset + piece as usize;
             for sq in board.colored_pieces(color, piece) {
-                let offset = sq as usize * (Piece::NUM * Color::NUM) + piece_idx;
-                features[offset] = 1.0;
+                let sq_idx = sq.relative_to(perspective) as usize;
+                features[sq_idx * (Piece::NUM * Color::NUM) + piece_idx] = 1.0;
             }
         }
     }
 
-    // White support
-    for sq in white_support {
-        features[WHITE_SUPPORT_START + sq as usize] = 1.0;
+    // Support
+    let (us_support, them_support) = from_perspective(white_support, black_support, perspective);
+    for sq in us_support {
+        features[US_SUPPORT_START + sq as usize] = 1.0;
+    }
+    for sq in them_support {
+        features[THEM_SUPPORT_START + sq as usize] = 1.0;
     }
 
-    // Black support
-    for sq in black_support {
-        features[BLACK_SUPPORT_START + sq as usize] = 1.0;
-    }
-
-    // White space (controlled non-piece squares)
+    // Space (controlled non-piece squares)
     let white_pieces = board.colors(Color::White);
     let white_space_bb = white_attacks & !white_pieces;
-    for sq in white_space_bb {
-        features[WHITE_SPACE_START + sq as usize] = 1.0;
-    }
-
-    // Black space
     let black_pieces = board.colors(Color::Black);
     let black_space_bb = black_attacks & !black_pieces;
-    for sq in black_space_bb {
-        features[BLACK_SPACE_START + sq as usize] = 1.0;
+    let (us_space, them_space) = from_perspective(white_space_bb, black_space_bb, perspective);
+    for sq in us_space {
+        features[US_SPACE_START + sq as usize] = 1.0;
+    }
+    for sq in them_space {
+        features[THEM_SPACE_START + sq as usize] = 1.0;
     }
 
-    // White threats
-    for sq in white_threats {
-        features[WHITE_THREATS_START + sq as usize] = 1.0;
+    // Threats
+    let (us_threats, them_threats) = from_perspective(white_threats, black_threats, perspective);
+    for sq in us_threats {
+        features[US_THREATS_START + sq as usize] = 1.0;
     }
-
-    // Black threats
-    for sq in black_threats {
-        features[BLACK_THREATS_START + sq as usize] = 1.0;
-    }
-
-    // Side to move
-    if board.side_to_move() == Color::White {
-        features[SIDE_TO_MOVE_IDX] = 1.0;
+    for sq in them_threats {
+        features[THEM_THREATS_START + sq as usize] = 1.0;
     }
 
     features
@@ -131,59 +98,53 @@ pub fn encode_board_bitset(
     black_support: BitBoard,
     white_threats: BitBoard,
     black_threats: BitBoard,
+    perspective: Color,
 ) -> Bitset<NUM_FEATURES> {
     let mut bitset = Bitset::default();
 
     // Piece placements
     for color in [Color::White, Color::Black] {
+        let side_offset = if color == perspective { 0 } else { Piece::NUM };
         for piece in Piece::ALL {
-            let piece_idx = piece_color_to_index(piece, color);
+            let piece_idx = side_offset + piece as usize;
             for sq in board.colored_pieces(color, piece) {
-                let idx = sq as usize * (Piece::NUM * Color::NUM) + piece_idx;
-                bitset.set(idx);
+                let sq_idx = sq.relative_to(perspective) as usize;
+                bitset.set(sq_idx * (Piece::NUM * Color::NUM) + piece_idx);
             }
         }
     }
 
-    // Support, space, and threats are 64-bit aligned - use bulk u64 assignment
-    // instead of iterating through each square
-    bitset.set_u64(bitset.u64_index(WHITE_SUPPORT_START), white_support.0);
-    bitset.set_u64(bitset.u64_index(BLACK_SUPPORT_START), black_support.0);
+    // The bitboard sections all start at 64-bit aligned offsets, so let's write
+    // whole ranks at once instead of iterating per square.
 
+    // Support
+    let (us_support, them_support) = from_perspective(white_support, black_support, perspective);
+    bitset.set_u64(bitset.u64_index(US_SUPPORT_START), us_support.0);
+    bitset.set_u64(bitset.u64_index(THEM_SUPPORT_START), them_support.0);
+
+    // Space (controlled non-piece squares)
     let white_pieces = board.colors(Color::White);
     let white_space_bb = white_attacks & !white_pieces;
-    bitset.set_u64(bitset.u64_index(WHITE_SPACE_START), white_space_bb.0);
-
     let black_pieces = board.colors(Color::Black);
     let black_space_bb = black_attacks & !black_pieces;
-    bitset.set_u64(bitset.u64_index(BLACK_SPACE_START), black_space_bb.0);
+    let (us_space, them_space) = from_perspective(white_space_bb, black_space_bb, perspective);
+    bitset.set_u64(bitset.u64_index(US_SPACE_START), us_space.0);
+    bitset.set_u64(bitset.u64_index(THEM_SPACE_START), them_space.0);
 
-    bitset.set_u64(bitset.u64_index(WHITE_THREATS_START), white_threats.0);
-    bitset.set_u64(bitset.u64_index(BLACK_THREATS_START), black_threats.0);
-
-    // Side to move
-    if board.side_to_move() == Color::White {
-        bitset.set(SIDE_TO_MOVE_IDX);
-    }
+    // Threats
+    let (us_threats, them_threats) = from_perspective(white_threats, black_threats, perspective);
+    bitset.set_u64(bitset.u64_index(US_THREATS_START), us_threats.0);
+    bitset.set_u64(bitset.u64_index(THEM_THREATS_START), them_threats.0);
 
     bitset
 }
 
-fn piece_color_to_index(piece: Piece, color: Color) -> usize {
-    match (color, piece) {
-        (Color::White, Piece::Pawn) => 0,
-        (Color::White, Piece::Knight) => 1,
-        (Color::White, Piece::Bishop) => 2,
-        (Color::White, Piece::Rook) => 3,
-        (Color::White, Piece::Queen) => 4,
-        (Color::White, Piece::King) => 5,
-
-        (Color::Black, Piece::Pawn) => 6,
-        (Color::Black, Piece::Knight) => 7,
-        (Color::Black, Piece::Bishop) => 8,
-        (Color::Black, Piece::Rook) => 9,
-        (Color::Black, Piece::Queen) => 10,
-        (Color::Black, Piece::King) => 11,
+/// Returns the (us, them) bitboard pair for the given perspective. From black,
+/// the ranks are flipped so rank 1 is always our back rank.
+fn from_perspective(white: BitBoard, black: BitBoard, perspective: Color) -> (BitBoard, BitBoard) {
+    match perspective {
+        Color::White => (white, black),
+        Color::Black => (black.flip_ranks(), white.flip_ranks()),
     }
 }
 
@@ -207,34 +168,39 @@ mod tests {
             let board: Board = fen.parse().unwrap();
             let metrics = BoardMetrics::new(&board);
 
-            let features = encode_board(
-                &board,
-                metrics.attacks[Color::White as usize],
-                metrics.attacks[Color::Black as usize],
-                metrics.support[Color::White as usize],
-                metrics.support[Color::Black as usize],
-                metrics.threats[Color::White as usize],
-                metrics.threats[Color::Black as usize],
-            );
-
-            let bitset = encode_board_bitset(
-                &board,
-                metrics.attacks[Color::White as usize],
-                metrics.attacks[Color::Black as usize],
-                metrics.support[Color::White as usize],
-                metrics.support[Color::Black as usize],
-                metrics.threats[Color::White as usize],
-                metrics.threats[Color::Black as usize],
-            );
-
-            for (i, &f) in features.iter().enumerate() {
-                assert_eq!(
-                    f == 1.0,
-                    bitset.get(i),
-                    "Mismatch at feature {} for FEN: {}",
-                    i,
-                    fen
+            for perspective in [Color::White, Color::Black] {
+                let features = encode_board(
+                    &board,
+                    metrics.attacks[Color::White as usize],
+                    metrics.attacks[Color::Black as usize],
+                    metrics.support[Color::White as usize],
+                    metrics.support[Color::Black as usize],
+                    metrics.threats[Color::White as usize],
+                    metrics.threats[Color::Black as usize],
+                    perspective,
                 );
+
+                let bitset = encode_board_bitset(
+                    &board,
+                    metrics.attacks[Color::White as usize],
+                    metrics.attacks[Color::Black as usize],
+                    metrics.support[Color::White as usize],
+                    metrics.support[Color::Black as usize],
+                    metrics.threats[Color::White as usize],
+                    metrics.threats[Color::Black as usize],
+                    perspective,
+                );
+
+                for (i, &f) in features.iter().enumerate() {
+                    assert_eq!(
+                        f == 1.0,
+                        bitset.get(i),
+                        "Mismatch at feature {} for FEN: {} ({:?})",
+                        i,
+                        fen,
+                        perspective
+                    );
+                }
             }
         }
     }

--- a/nnue/src/evaluator.rs
+++ b/nnue/src/evaluator.rs
@@ -1,6 +1,6 @@
 use candle_nn::{VarBuilder, VarMap};
 use cozy_chess::Color;
-use utils::Node;
+use utils::{Node, flip_eval_perspective};
 
 use crate::{
     encoding::encode_board_bitset,
@@ -36,8 +36,12 @@ impl Evaluator {
     }
 
     /// Evaluates the position using the neural network.
+    ///
+    /// Returns the score from white's perspective.
     pub fn evaluate(&mut self, node: &Node) -> i16 {
         let board = node.board();
+        let stm = board.side_to_move();
+
         let white_attacks = node.attacks_for(Color::White);
         let black_attacks = node.attacks_for(Color::Black);
         let white_support = node.support_for(Color::White);
@@ -45,7 +49,7 @@ impl Evaluator {
         let white_threats = node.threats_for(Color::White);
         let black_threats = node.threats_for(Color::Black);
 
-        let bitset = encode_board_bitset(
+        let white_bits = encode_board_bitset(
             board,
             white_attacks,
             black_attacks,
@@ -53,14 +57,30 @@ impl Evaluator {
             black_support,
             white_threats,
             black_threats,
+            Color::White,
+        );
+        let black_bits = encode_board_bitset(
+            board,
+            white_attacks,
+            black_attacks,
+            white_support,
+            black_support,
+            white_threats,
+            black_threats,
+            Color::Black,
         );
 
         let bucket = output_bucket(board);
 
-        self.nnue
+        let stm_score = self
+            .nnue
             .as_mut()
             .expect("NNUE network not initialized - call enable_nnue() first")
-            .forward(&bitset, bucket)
-            .clamp(i16::MIN as f32, i16::MAX as f32) as i16
+            .forward(&white_bits, &black_bits, stm, bucket);
+
+        let stm_score = stm_score.clamp(i16::MIN as f32, i16::MAX as f32) as i16;
+
+        // Return the score as white
+        flip_eval_perspective(stm, stm_score)
     }
 }

--- a/nnue/src/network/accumulator.rs
+++ b/nnue/src/network/accumulator.rs
@@ -2,6 +2,7 @@ use std::simd::i8x32;
 use std::simd::num::SimdInt;
 use std::simd::prelude::SimdFloat;
 
+use cozy_chess::Color;
 use utils::bitset::Bitset;
 
 use crate::encoding::NUM_FEATURES;
@@ -16,6 +17,9 @@ use super::{EMBEDDING_SIZE, QUANTIZATION_PERCENTILE};
 /// the corresponding weight rows. This makes inference O(changed features)
 /// rather than O(all features).
 ///
+/// The embedding is shared across both perspectives, so we run it twice
+/// against the same weights and keep one buffer per absolute color.
+///
 /// Weights are quantized to i8 and accumulated in i16 for wider SIMD.
 /// Dequantization back to f32 happens when outputting to the next layer.
 pub struct Accumulator {
@@ -24,10 +28,12 @@ pub struct Accumulator {
     // [embedding_idx]
     biases: Vec<i16>,
     // Accumulated sum of active weights [embedding_idx]
-    buffer: [i16; EMBEDDING_SIZE],
+    buffer_white: [i16; EMBEDDING_SIZE],
+    buffer_black: [i16; EMBEDDING_SIZE],
 
     // To know which inputs have changed since the last update
-    previous_input: Bitset<NUM_FEATURES>,
+    previous_white: Bitset<NUM_FEATURES>,
+    previous_black: Bitset<NUM_FEATURES>,
 
     // Per-neuron weight quantization scale factors to convert it back to f32.
     // USes 1/scale to avoid slower division operations.
@@ -41,43 +47,60 @@ impl Accumulator {
         let weights_i8 = quantize_embedding_weights(weights, &scales);
         let biases_i16 = quantize_embedding_biases(biases, &scales);
 
-        let mut buffer = [0i16; EMBEDDING_SIZE];
-        buffer.copy_from_slice(&biases_i16);
+        let mut buffer_white = [0i16; EMBEDDING_SIZE];
+        let mut buffer_black = [0i16; EMBEDDING_SIZE];
+        buffer_white.copy_from_slice(&biases_i16);
+        buffer_black.copy_from_slice(&biases_i16);
 
         Self {
             weights: weights_i8,
             biases: biases_i16,
-            buffer,
-            previous_input: Bitset::default(),
+            buffer_white,
+            buffer_black,
+            previous_white: Bitset::default(),
+            previous_black: Bitset::default(),
             inv_scales,
         }
     }
 
     pub fn reset(&mut self) {
-        self.buffer.copy_from_slice(&self.biases);
-        self.previous_input = Bitset::default();
+        self.buffer_white.copy_from_slice(&self.biases);
+        self.buffer_black.copy_from_slice(&self.biases);
+        self.previous_white = Bitset::default();
+        self.previous_black = Bitset::default();
     }
 
-    /// Updates the accumulator based on the difference between previous and current inputs.
-    pub fn update(&mut self, new_input: &Bitset<NUM_FEATURES>) {
-        // TODO: Look into if we can avoid cloning this.
-        self.previous_input.clone().for_each_diff(new_input, |idx| {
+    /// Updates the accumulators based on the difference between previous and current inputs.
+    pub fn update(&mut self, color: Color, new_input: &Bitset<NUM_FEATURES>) {
+        let previous = match color {
+            Color::White => self.previous_white,
+            Color::Black => self.previous_black,
+        };
+
+        previous.for_each_diff(new_input, |idx| {
             let is_active = new_input.get(idx);
-            self.apply_feature_change(idx, is_active);
+            self.apply_feature_change(color, idx, is_active);
         });
 
-        self.previous_input = *new_input;
+        match color {
+            Color::White => self.previous_white = *new_input,
+            Color::Black => self.previous_black = *new_input,
+        }
     }
 
-    fn apply_feature_change(&mut self, feature_idx: usize, add: bool) {
-        let offset: usize = feature_idx * EMBEDDING_SIZE;
+    fn apply_feature_change(&mut self, color: Color, feature_idx: usize, add: bool) {
+        let offset = feature_idx * EMBEDDING_SIZE;
         let weights_row = &self.weights[offset..offset + EMBEDDING_SIZE];
+        let buffer = match color {
+            Color::White => &mut self.buffer_white,
+            Color::Black => &mut self.buffer_black,
+        };
 
         let mut i = 0;
 
         while i + SIMD_WIDTH_I16 <= EMBEDDING_SIZE {
             // Load current buffer values
-            let mut buffer_vec = SimdI16::from_slice(&self.buffer[i..i + SIMD_WIDTH_I16]);
+            let mut buffer_vec = SimdI16::from_slice(&buffer[i..i + SIMD_WIDTH_I16]);
 
             // Load and widen weights (i8 -> i16)
             let weights_i8 = i8x32::from_slice(&weights_row[i..i + SIMD_WIDTH_I16]);
@@ -89,7 +112,7 @@ impl Accumulator {
                 buffer_vec -= weights_i16;
             }
 
-            buffer_vec.copy_to_slice(&mut self.buffer[i..i + SIMD_WIDTH_I16]);
+            buffer_vec.copy_to_slice(&mut buffer[i..i + SIMD_WIDTH_I16]);
             i += SIMD_WIDTH_I16;
         }
 
@@ -97,21 +120,27 @@ impl Accumulator {
         while i < EMBEDDING_SIZE {
             let w = weights_row[i] as i16;
             if add {
-                self.buffer[i] += w;
+                buffer[i] += w;
             } else {
-                self.buffer[i] -= w;
+                buffer[i] -= w;
             }
             i += 1;
         }
     }
 
-    /// Converts the accumulated i16 buffer into f32 activations with ReLU applied.
-    pub fn dequantize_and_relu(&self, output: &mut [f32; EMBEDDING_SIZE]) {
+    /// Converts the accumulated i16 buffer for `color` into f32 activations with ReLU applied.
+    pub fn dequantize_and_relu(&self, color: Color, output: &mut [f32]) {
+        debug_assert_eq!(output.len(), EMBEDDING_SIZE);
+        let buffer = match color {
+            Color::White => &self.buffer_white,
+            Color::Black => &self.buffer_black,
+        };
+
         let zeros = SimdF32::splat(0.0);
 
         let mut i = 0;
         while i + SIMD_WIDTH_F32 <= EMBEDDING_SIZE {
-            let vals_i16 = &self.buffer[i..i + SIMD_WIDTH_F32];
+            let vals_i16 = &buffer[i..i + SIMD_WIDTH_F32];
             let vals_f32 = SimdF32::from_array(std::array::from_fn(|j| vals_i16[j] as f32));
             let scale_vec = SimdF32::from_slice(&self.inv_scales[i..i + SIMD_WIDTH_F32]);
 
@@ -124,7 +153,7 @@ impl Accumulator {
 
         // Cleanup remaining outside SIMD width
         while i < EMBEDDING_SIZE {
-            output[i] = (self.buffer[i] as f32 * self.inv_scales[i]).max(0.0);
+            output[i] = (buffer[i] as f32 * self.inv_scales[i]).max(0.0);
             i += 1;
         }
     }

--- a/nnue/src/network/inference.rs
+++ b/nnue/src/network/inference.rs
@@ -1,4 +1,5 @@
 use candle_core::Result;
+use cozy_chess::Color;
 use utils::bitset::Bitset;
 
 use crate::encoding::NUM_FEATURES;
@@ -9,13 +10,15 @@ use super::model::Network;
 use super::simd::{simd_add, simd_relu};
 use super::{CP_BOUND, EMBEDDING_SIZE, FV_SCALE, HIDDEN_SIZE, OUTPUT_BUCKETS};
 
-/// NNUE inference engine with quantized weights.
-/// Uses an incremental accumulator for the embedding layer and
-/// phase-specific output stacks selected by piece count.
+/// NNUE inference engine with quantized weights and dual-perspective accumulators.
+///
+/// The accumulator holds one running buffer per absolute color; `forward`
+/// picks which one goes into the stm half of the concat buffer based on the
+/// current side-to-move.
 pub struct NNUENetwork {
     accumulator: Accumulator,
     buckets: [OutputStack; OUTPUT_BUCKETS],
-    embedding_buffer: [f32; EMBEDDING_SIZE],
+    embedding_buffer: [f32; 2 * EMBEDDING_SIZE],
 }
 
 impl NNUENetwork {
@@ -40,7 +43,7 @@ impl NNUENetwork {
         Ok(Self {
             accumulator,
             buckets,
-            embedding_buffer: [0.0; EMBEDDING_SIZE],
+            embedding_buffer: [0.0; 2 * EMBEDDING_SIZE],
         })
     }
 
@@ -48,13 +51,25 @@ impl NNUENetwork {
         self.accumulator.reset();
     }
 
-    /// Forward pass with incremental updates from a bitset.
+    /// Forward pass with color-keyed inputs. `white_bits` and `black_bits` are
+    /// the encodings of the current board from each perspective; `stm` decides
+    /// which color's activations land in the stm half of the concat buffer.
     /// Use `output_bucket(&board)` to compute the bucket index.
     #[inline]
-    pub fn forward(&mut self, bitset: &Bitset<NUM_FEATURES>, bucket: usize) -> f32 {
-        self.accumulator.update(bitset);
-        self.accumulator
-            .dequantize_and_relu(&mut self.embedding_buffer);
+    pub fn forward(
+        &mut self,
+        white_bits: &Bitset<NUM_FEATURES>,
+        black_bits: &Bitset<NUM_FEATURES>,
+        stm: Color,
+        bucket: usize,
+    ) -> f32 {
+        self.accumulator.update(Color::White, white_bits);
+        self.accumulator.update(Color::Black, black_bits);
+
+        let nstm = !stm;
+        let (stm_half, nstm_half) = self.embedding_buffer.split_at_mut(EMBEDDING_SIZE);
+        self.accumulator.dequantize_and_relu(stm, stm_half);
+        self.accumulator.dequantize_and_relu(nstm, nstm_half);
 
         let output = self.buckets[bucket].forward(&self.embedding_buffer);
 

--- a/nnue/src/network/mod.rs
+++ b/nnue/src/network/mod.rs
@@ -10,7 +10,7 @@ pub use linear::LinearLayer;
 pub use model::Network;
 
 /// Size of the accumulator that input features are embedded into.
-pub const EMBEDDING_SIZE: usize = 1024;
+pub const EMBEDDING_SIZE: usize = 768;
 
 /// Size of the hidden layers after the embedding.
 pub const HIDDEN_SIZE: usize = 16;

--- a/nnue/src/network/model.rs
+++ b/nnue/src/network/model.rs
@@ -6,7 +6,10 @@ use crate::encoding::NUM_FEATURES;
 use super::{EMBEDDING_SIZE, HIDDEN_SIZE, OUTPUT_BUCKETS};
 
 /// Full-precision network for training and weight loading.
-/// Shared embedding layer with phase-specific output stacks.
+///
+/// A single embedding layer is run over both perspectives and the outputs are
+/// concatenated [...stm, ...nstm] before being fed to the phase-specific hidden
+/// stack.
 pub struct Network {
     pub embedding: Linear,
     pub buckets: [OutputStack; OUTPUT_BUCKETS],
@@ -19,7 +22,7 @@ impl Network {
         let buckets: [OutputStack; OUTPUT_BUCKETS] = std::array::from_fn(|i| {
             let bvs = vs.pp(format!("bucket_{}", i));
             OutputStack {
-                hidden1: linear(EMBEDDING_SIZE, HIDDEN_SIZE, bvs.pp("hidden1")).unwrap(),
+                hidden1: linear(2 * EMBEDDING_SIZE, HIDDEN_SIZE, bvs.pp("hidden1")).unwrap(),
                 hidden2: linear(HIDDEN_SIZE, HIDDEN_SIZE, bvs.pp("hidden2")).unwrap(),
                 output: linear(HIDDEN_SIZE, 1, bvs.pp("output")).unwrap(),
             }
@@ -36,9 +39,15 @@ impl Network {
     /// Computes all bucket outputs, then gathers the correct one per sample.
     /// During backprop, `gather` scatters gradients only to each sample's
     /// selected bucket—unused buckets receive zero gradient for that sample.
+    ///
+    /// `stm` and `nstm` are feature tensors for the side-to-move and opponent
+    /// perspectives of the same position. The output is in stm-perspective
+    /// space; callers that need a white-perspective value must sign-flip.
     #[inline]
-    pub fn forward(&self, x: &Tensor, buckets: &[usize]) -> Result<Tensor> {
-        let embedding_out = x.apply(&self.embedding)?.relu()?;
+    pub fn forward(&self, stm: &Tensor, nstm: &Tensor, buckets: &[usize]) -> Result<Tensor> {
+        let stm_embed = stm.apply(&self.embedding)?.relu()?;
+        let nstm_embed = nstm.apply(&self.embedding)?.relu()?;
+        let embedding_out = Tensor::cat(&[stm_embed, nstm_embed], 1)?;
 
         // Compute all bucket outputs: [batch, OUTPUT_BUCKETS]
         let all_outputs: Vec<_> = self

--- a/training/src/bin/train/dataset/loader.rs
+++ b/training/src/bin/train/dataset/loader.rs
@@ -9,7 +9,8 @@ use super::shard_reader::ShardReader;
 const CHANNEL_BUFFER_MULTIPLIER: usize = 2;
 
 pub struct Batch {
-    pub features: Vec<f32>,
+    pub stm_features: Vec<f32>,
+    pub nstm_features: Vec<f32>,
     pub scores: Vec<f32>,
     pub outcomes: Vec<f32>,
     pub buckets: Vec<usize>,
@@ -68,7 +69,8 @@ impl DataLoader {
     }
 
     fn collect_batch(reader: &ShardReader, batch_size: usize, shutdown: &AtomicBool) -> Batch {
-        let mut features = Vec::with_capacity(batch_size * NUM_FEATURES);
+        let mut stm_features = Vec::with_capacity(batch_size * NUM_FEATURES);
+        let mut nstm_features = Vec::with_capacity(batch_size * NUM_FEATURES);
         let mut scores = Vec::with_capacity(batch_size);
         let mut outcomes = Vec::with_capacity(batch_size);
         let mut buckets = Vec::with_capacity(batch_size);
@@ -81,7 +83,8 @@ impl DataLoader {
             match reader.next() {
                 Some(sample) => {
                     if let Some(encoded) = sample.encode() {
-                        features.extend_from_slice(&encoded.features);
+                        stm_features.extend_from_slice(&encoded.stm_features);
+                        nstm_features.extend_from_slice(&encoded.nstm_features);
                         scores.push(encoded.score);
                         outcomes.push(encoded.outcome);
                         buckets.push(encoded.bucket);
@@ -92,7 +95,8 @@ impl DataLoader {
         }
 
         Batch {
-            features,
+            stm_features,
+            nstm_features,
             scores,
             outcomes,
             buckets,

--- a/training/src/bin/train/dataset/shard.rs
+++ b/training/src/bin/train/dataset/shard.rs
@@ -17,7 +17,8 @@ pub struct Sample {
 }
 
 pub struct EncodedSample {
-    pub features: [f32; NUM_FEATURES],
+    pub stm_features: [f32; NUM_FEATURES],
+    pub nstm_features: [f32; NUM_FEATURES],
     pub score: f32,
     pub outcome: f32,
     pub bucket: usize,
@@ -27,10 +28,10 @@ impl Sample {
     pub fn encode(&self) -> Option<EncodedSample> {
         let board = Board::from_str(&self.fen).ok()?;
         let metrics = BoardMetrics::new(&board);
+        let stm = board.side_to_move();
+        let nstm = !stm;
 
-        let score = self.score as f32 / FV_SCALE;
-        let bucket = output_bucket(&board);
-        let features = encode_board(
+        let stm_features = encode_board(
             &board,
             metrics.attacks[Color::White as usize],
             metrics.attacks[Color::Black as usize],
@@ -38,13 +39,32 @@ impl Sample {
             metrics.support[Color::Black as usize],
             metrics.threats[Color::White as usize],
             metrics.threats[Color::Black as usize],
+            stm,
+        );
+        let nstm_features = encode_board(
+            &board,
+            metrics.attacks[Color::White as usize],
+            metrics.attacks[Color::Black as usize],
+            metrics.support[Color::White as usize],
+            metrics.support[Color::Black as usize],
+            metrics.threats[Color::White as usize],
+            metrics.threats[Color::Black as usize],
+            nstm,
         );
 
+        let white_score = self.score as f32 / FV_SCALE;
+        let white_outcome = self.outcome;
+        let (score, outcome) = match stm {
+            Color::White => (white_score, white_outcome),
+            Color::Black => (-white_score, 1.0 - white_outcome),
+        };
+
         Some(EncodedSample {
+            stm_features,
+            nstm_features,
             score,
-            outcome: self.outcome,
-            bucket,
-            features,
+            outcome,
+            bucket: output_bucket(&board),
         })
     }
 }

--- a/training/src/bin/train/training/evaluation.rs
+++ b/training/src/bin/train/training/evaluation.rs
@@ -21,11 +21,12 @@ pub fn evaluate(
             continue;
         }
 
-        let x = Tensor::from_vec(batch.features, (batch_len, NUM_FEATURES), device)?;
+        let stm = Tensor::from_vec(batch.stm_features, (batch_len, NUM_FEATURES), device)?;
+        let nstm = Tensor::from_vec(batch.nstm_features, (batch_len, NUM_FEATURES), device)?;
         let y_eval = Tensor::from_vec(batch.scores, (batch_len, 1), device)?;
         let y_outcome = Tensor::from_vec(batch.outcomes, (batch_len, 1), device)?;
 
-        let preds = network.forward(&x, &batch.buckets)?;
+        let preds = network.forward(&stm, &nstm, &batch.buckets)?;
         let loss = wdl_eval_loss(&preds, &y_eval, &y_outcome, wdl)?;
 
         total_loss += loss.to_vec0::<f32>()?;

--- a/training/src/bin/train/training/trainer.rs
+++ b/training/src/bin/train/training/trainer.rs
@@ -138,11 +138,14 @@ impl Trainer {
                 continue;
             }
 
-            let x = Tensor::from_vec(batch.features, (batch_len, NUM_FEATURES), &self.device)?;
+            let stm =
+                Tensor::from_vec(batch.stm_features, (batch_len, NUM_FEATURES), &self.device)?;
+            let nstm =
+                Tensor::from_vec(batch.nstm_features, (batch_len, NUM_FEATURES), &self.device)?;
             let y_eval = Tensor::from_vec(batch.scores, (batch_len, 1), &self.device)?;
             let y_outcome = Tensor::from_vec(batch.outcomes, (batch_len, 1), &self.device)?;
 
-            let preds = self.network.forward(&x, &batch.buckets)?;
+            let preds = self.network.forward(&stm, &nstm, &batch.buckets)?;
             let loss = wdl_eval_loss(&preds, &y_eval, &y_outcome, self.wdl)?;
 
             self.optimizer.backward_step(&loss)?;


### PR DESCRIPTION
Work in progress.

### Rationale

After implementing the NNUE analysis tool it is clear that the STM feature (the single bit) does a lot more than the other features:

```
  feature groups (column norms, x pieces):
    pieces   ( 768 feats): norm 3.7408 (1.00x)
    support  ( 128 feats): norm 1.3696 (0.37x)
    space    ( 128 feats): norm 1.1618 (0.31x)
    threats  ( 128 feats): norm 3.0615 (0.82x)
    stm      (   1 feats): norm 6.5473 (1.75x)
```

So my thinking is that the majority of capacity in the accumulator goes towards the stm information. The standard approach in modern engines is to use a dual-perspective accumulator, but I have been keeping it simple until now using a stm feature.

I guess it is time to try.