### PR TITLE
perf: add PV move anti-reduction

### DIFF
--- a/search/src/config.rs
+++ b/search/src/config.rs
@@ -114,6 +114,7 @@ define_config!(
     (reduction_not_improving: u16, "Reduction Not Improving", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
     (anti_reduction_near_root: u16, "Anti Reduction Near Root", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
     (anti_reduction_pv_node: u16, "Anti Reduction PV Node", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
+    (anti_reduction_pv_move: u16, "Anti Reduction PV Move", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
     (anti_reduction_tactical: u16, "Anti Reduction Tactical", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
     (anti_reduction_threat: u16, "Anti Reduction Threat", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
     (anti_reduction_check: u16, "Anti Reduction Check", UciOptionType::Spin { min: 0, max: 4096 }, 1500, cfg!(feature = "tuning")),

--- a/search/src/searcher/reduction.rs
+++ b/search/src/searcher/reduction.rs
@@ -28,10 +28,6 @@ impl Searcher {
         hist: i16,
         cont_hist: i16,
     ) -> Reduction {
-        if is_pv_move {
-            return Reduction::Reduce(0);
-        }
-
         let mut reduction = self.lmr.get(depth, move_index);
 
         // Reduce more
@@ -57,6 +53,9 @@ impl Searcher {
 
         // Reduce less
         if reduction > FracPly(0) {
+            if is_pv_move {
+                reduction -= FracPly(self.config.anti_reduction_pv_move.value);
+            }
             if near_root(ply, depth) {
                 reduction -= FracPly(self.config.anti_reduction_near_root.value);
             }


### PR DESCRIPTION
## Summary

For now, removing the hard no-reduction guard for pv moves regressed.
Now after trying various experiments with reductions I found removing it to no longer regress, and instead gain Elo.

So this PR replaces the no-reduction guard for PV moves with an anti-reduction so PV moves can be reduced.