### PR TITLE
perf: depth-scale quiet history pruning

### DIFF
--- a/search/src/config.rs
+++ b/search/src/config.rs
@@ -89,7 +89,7 @@ define_config!(
     (aspiration_score_divisor: i32, "Aspiration Score Divisor", UciOptionType::Spin { min: 1024, max: 65536 }, 16384, cfg!(feature = "tuning")),
 
     (history_max_value: i32, "History Max Value", UciOptionType::Spin { min: 128, max: 1024 }, 512, cfg!(feature = "tuning")),
-    (history_prune_threshold: i16, "History Prune Threshold", UciOptionType::Spin { min: -512, max: 512 }, -64, cfg!(feature = "tuning")),
+    (history_prune_depth_multiplier: i16, "History Prune Depth Multiplier", UciOptionType::Spin { min: -256, max: 0 }, -80, cfg!(feature = "tuning")),
     (history_bonus_multiplier: i32, "History Bonus Multiplier", UciOptionType::Spin { min: 0, max: 30 }, 13, cfg!(feature = "tuning")),
     (history_malus_multiplier: i32, "History Malus Multiplier", UciOptionType::Spin { min: 0, max: 30 }, 4, cfg!(feature = "tuning")),
 

--- a/search/src/history/history_heuristic.rs
+++ b/search/src/history/history_heuristic.rs
@@ -14,24 +14,17 @@ pub struct HistoryHeuristic {
     history: Vec<i16>,
 
     max_history: i32,
-    prune_threshold: i16,
 
     bonus_multiplier: i32,
     malus_multiplier: i32,
 }
 
 impl HistoryHeuristic {
-    pub fn new(
-        max_history: i32,
-        prune_threshold: i16,
-        bonus_multiplier: i32,
-        malus_multiplier: i32,
-    ) -> Self {
+    pub fn new(max_history: i32, bonus_multiplier: i32, malus_multiplier: i32) -> Self {
         Self {
             history: vec![0; HISTORY_SIZE],
 
             max_history,
-            prune_threshold,
 
             bonus_multiplier,
             malus_multiplier,
@@ -40,7 +33,6 @@ impl HistoryHeuristic {
 
     pub fn configure(&mut self, config: &EngineConfig) {
         self.max_history = config.history_max_value.value;
-        self.prune_threshold = config.history_prune_threshold.value;
 
         self.bonus_multiplier = config.history_bonus_multiplier.value;
         self.malus_multiplier = config.history_malus_multiplier.value;
@@ -50,7 +42,6 @@ impl HistoryHeuristic {
 
     pub fn matches_config(&self, config: &EngineConfig) -> bool {
         self.max_history == config.history_max_value.value
-            && self.prune_threshold == config.history_prune_threshold.value
             && self.bonus_multiplier == config.history_bonus_multiplier.value
             && self.malus_multiplier == config.history_malus_multiplier.value
     }
@@ -82,10 +73,6 @@ impl HistoryHeuristic {
         let source_stride = Square::NUM;
 
         color_idx * color_stride + source_idx * source_stride + dest_idx
-    }
-
-    pub fn prune_threshold(&self) -> i16 {
-        self.prune_threshold
     }
 
     pub fn get_bonus(&self, depth: u8) -> i32 {

--- a/search/src/searcher/mod.rs
+++ b/search/src/searcher/mod.rs
@@ -112,7 +112,7 @@ impl Searcher {
 
             search_stack: SearchStack::with_capacity(MAX_DEPTH),
 
-            history_heuristic: HistoryHeuristic::new(1, 1, 1, 1),
+            history_heuristic: HistoryHeuristic::new(1, 1, 1),
             capture_history: CaptureHistory::new(1, 1, 1),
             continuation_history: Box::new(ContinuationHistory::new(1, 1, 1, 1)),
 

--- a/search/src/searcher/reduction.rs
+++ b/search/src/searcher/reduction.rs
@@ -73,18 +73,15 @@ impl Searcher {
             }
         }
 
-        let r = reduction.whole().min(depth.saturating_sub(2));
-
-        // Prune when bad history if it would barely search anyway
-        let reduced_depth = depth.saturating_sub(r);
-        if !is_capture
-            && !is_improving
-            && hist < self.history_heuristic.prune_threshold()
-            && reduced_depth <= 1
-        {
+        // Prune quiet moves with bad history.
+        let history_score = hist as i32 + cont_hist as i32;
+        let prune_threshold =
+            self.config.history_prune_depth_multiplier.value as i32 * depth as i32;
+        if !is_pv_move && !is_capture && !is_improving && history_score < prune_threshold {
             return Reduction::Prune;
         }
 
+        let r = reduction.whole().min(depth.saturating_sub(2));
         Reduction::Reduce(r)
     }
 }


### PR DESCRIPTION
## Summary

The previous quiet history prune was a single hard threshold on main history at the frontier. It also lived on `HistoryHeuristic`, which felt weird since everything just uses the config directly. Old code that was implemented before the context reductions and never got a refactoring. 

This rewrites it to:
- Combines history and continuation history.
- Threshold scales with depth.
- Skips pruning for the first move.