### PR TITLE
perf: reduce more if tt is capture

### DIFF
--- a/search/src/config.rs
+++ b/search/src/config.rs
@@ -112,6 +112,7 @@ define_config!(
 
     (reduction_cut_node: u16, "Reduction Cut Node", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
     (reduction_not_improving: u16, "Reduction Not Improving", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
+    (reduction_tt_capture: u16, "Reduction TT Capture", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
     (anti_reduction_near_root: u16, "Anti Reduction Near Root", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
     (anti_reduction_pv_node: u16, "Anti Reduction PV Node", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
     (anti_reduction_pv_move: u16, "Anti Reduction PV Move", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),

--- a/search/src/searcher/reduction.rs
+++ b/search/src/searcher/reduction.rs
@@ -27,6 +27,7 @@ impl Searcher {
         child: &Node,
         hist: i16,
         cont_hist: i16,
+        tt_move_is_capture: bool,
     ) -> Reduction {
         let mut reduction = self.lmr.get(depth, move_index);
 
@@ -36,6 +37,9 @@ impl Searcher {
         }
         if !is_improving {
             reduction += FracPly(self.config.reduction_not_improving.value);
+        }
+        if !is_pv_move && tt_move_is_capture {
+            reduction += FracPly(self.config.reduction_tt_capture.value);
         }
 
         let hist_divisor = if is_capture {

--- a/search/src/searcher/search.rs
+++ b/search/src/searcher/search.rs
@@ -297,6 +297,7 @@ impl Searcher {
 
         let in_check = node.in_check();
         let tt_move = tt_info.and_then(|t| t.best_move);
+        let tt_move_is_capture = tt_move.is_some_and(|m| node.is_capture(m));
 
         let static_eval = tt_info
             .and_then(|t| t.static_eval)
@@ -435,6 +436,7 @@ impl Searcher {
                 is_improving,
                 corrected_eval,
                 singular_result.extension,
+                tt_move_is_capture,
             ) {
                 if self.shared.is_stopped() {
                     break;
@@ -523,6 +525,7 @@ impl Searcher {
         is_improving: bool,
         static_eval: i16,
         extra_extension: i8,
+        tt_move_is_capture: bool,
     ) -> Option<(i16, bool, u8)> {
         let moved_color = node.board().side_to_move();
         let moved_piece = node.piece_on(m.from).unwrap();
@@ -581,6 +584,7 @@ impl Searcher {
             &child,
             hist,
             cont_hist,
+            tt_move_is_capture,
         ) {
             Reduction::Reduce(r) => r,
             Reduction::Prune => return None,


### PR DESCRIPTION
## Summary

Modern engines tend to reduce other moves more if the best move from TT is a capture.

### Caveat

Very interesting side-effect, but `next` seems to have higher NPS than after this change. I don't find this intuitive. Compiler lottery? Anyways:


**This branch**
```
info depth 20 seldepth 30 multipv 1 score cp 48 nodes 3572736 nps 952918 hashfull 95 time 3749 pv d2d4 g8f6 c2c4 e7e6 b1c3 f8b4 c1d2 c7c5 d4d5 e6d5 c4d5 e8g8 e2e3 d7d6 g1e2 b8d7 e2f4 f8e8 f1e2 a7a6 a2a3 b4a5
```

**Next**
```
info depth 20 seldepth 31 multipv 1 score cp 33 nodes 6348800 nps 1076163 hashfull 196 time 5899 pv c2c4 c7c5 g1f3 g8f6 e2e3 e7e6 f1e2 f8e7 b1c3 e8g8 e1g1 d7d5 c4d5 f6d5 b2b3 d5c3 d2c3 d8c7 d1c2 b7b6 c1b2 c8b7 e2d3 h7h6 c3c4
```

To mitigate the NPS difference I will be running SPRT with tunable grail setting the flag as:

```
  -engine cmd=./target/release/grail name=candidate "option.Reduction TT Capture=1024"\
  -engine cmd=./target/release/grail name=baseline "option.Reduction TT Capture=0" \
```
