### PR TITLE
perf: reduce quiet moves when TT move is a capture

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -47,6 +47,7 @@ define_config!(
 
     (reduction_cut_node: u16, "Reduction Cut Node", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
     (reduction_not_improving: u16, "Reduction Not Improving", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
+    (reduction_quiets_if_tt_capture: u16, "Reduction Quiets If TT Capture", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
     (anti_reduction_near_root: u16, "Anti Reduction Near Root", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
     (anti_reduction_pv_node: u16, "Anti Reduction PV Node", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
     (anti_reduction_pv_move: u16, "Anti Reduction PV Move", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),

--- a/search/src/searcher/reduction.rs
+++ b/search/src/searcher/reduction.rs
@@ -22,6 +22,7 @@ impl Searcher {
         child: &Node,
         hist: i16,
         cont_hist: i16,
+        tt_move_is_capture: bool,
     ) -> u8 {
         let mut reduction = self.lmr.get(depth, move_index);
 
@@ -31,6 +32,9 @@ impl Searcher {
         }
         if !is_improving {
             reduction += FracPly(self.config.reduction_not_improving.value);
+        }
+        if tt_move_is_capture && !is_capture {
+            reduction += FracPly(self.config.reduction_quiets_if_tt_capture.value);
         }
 
         let hist_divisor = if is_capture {

--- a/search/src/searcher/search.rs
+++ b/search/src/searcher/search.rs
@@ -296,6 +296,7 @@ impl Searcher {
 
         let in_check = node.in_check();
         let tt_move = tt_info.and_then(|t| t.best_move);
+        let tt_move_is_capture = tt_move.is_some_and(|m| node.is_capture(m));
 
         let static_eval = tt_info
             .and_then(|t| t.static_eval)
@@ -441,6 +442,7 @@ impl Searcher {
                 in_check,
                 move_index,
                 is_improving,
+                tt_move_is_capture,
                 corrected_eval,
                 singular_result.extension,
             ) {
@@ -522,6 +524,7 @@ impl Searcher {
         in_check: bool,
         move_index: i32,
         is_improving: bool,
+        tt_move_is_capture: bool,
         static_eval: i16,
         extra_extension: i8,
     ) -> Option<(i16, bool, u8)> {
@@ -587,6 +590,7 @@ impl Searcher {
             &child,
             hist,
             cont_hist,
+            tt_move_is_capture,
         );
 
         let extension = self.get_extension(node, &m, moved_piece, is_cap);


### PR DESCRIPTION
## Summary

Common technique that if the TT best move is a capture we reduce all quiet moves in the same postiion. Probably because the position is most likely tactical (?).

Also this for some reason reduces NPS a bit on mac for whatever reason... Could be the extra parameter making the compiler not inline the function, so I will test inlining absolutely everything later. But for this PR I just test the same binary with reduction 0 for the baseline and 1024 for the candidate.