### PR TITLE
perf: use TT eval for razoring

### DIFF
--- a/search/src/searcher/pruning.rs
+++ b/search/src/searcher/pruning.rs
@@ -56,14 +56,14 @@ impl Searcher {
         alpha: i16,
         ply: u8,
         in_check: bool,
-        static_eval: i16,
+        eval: i16,
     ) -> Option<i16> {
         if depth == 0 || depth > self.config.razor_max_depth.value || in_check {
             return None;
         }
         let margin = self.config.razor_base_margin.value
             + self.config.razor_depth_coefficient.value * (depth as i16 * depth as i16);
-        if static_eval >= alpha - margin {
+        if eval >= alpha - margin {
             return None;
         }
         let value = self.quiescence_search(node, Bounds::null(alpha - 1), ply);

--- a/search/src/searcher/search.rs
+++ b/search/src/searcher/search.rs
@@ -322,7 +322,7 @@ impl Searcher {
         // I also saw success skipping razoring.
         if singular.is_none() {
             if let Some(score) =
-                self.try_razor_prune(node, depth, bounds.alpha, ply, in_check, corrected_eval)
+                self.try_razor_prune(node, depth, bounds.alpha, ply, in_check, stack_eval)
             {
                 return score;
             }


### PR DESCRIPTION
## Summary

Use TT eval for razoring since it is a more refined evaluation than the static eval.