### PR TITLE
feat: adjustable draw target for WDL

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ The trainer loads all CSV files from `nnue/data/` and saves the best model to `n
 - `--patience`: Epochs without improvement before early stopping (default: 5).
 - `--shard-size-mb`: Size of each data shard in megabytes (default: 500).
 - `--wdl`: WDL blending weight, 0.0 = pure eval, 1.0 = pure WDL (default: 0.3).
+- `--draw-target`: Target win-probability for drawn games, smaller = prefer wins over draws (default: 0.5).
 - `--init-model`: Save a randomly initialized model and exit.
 
 ## Acknowledgements

--- a/training/src/bin/train/args.rs
+++ b/training/src/bin/train/args.rs
@@ -45,6 +45,10 @@ pub struct Args {
     #[arg(long, default_value_t = 0.3)]
     pub wdl: f64,
 
+    /// Target win-probability for drawn games (smaller = prefer wins over draws).
+    #[arg(long, default_value_t = 0.5)]
+    pub draw_target: f64,
+
     /// Save a randomly initialized model and exit.
     #[arg(long)]
     pub init_model: bool,

--- a/training/src/bin/train/dataset/loader.rs
+++ b/training/src/bin/train/dataset/loader.rs
@@ -31,6 +31,7 @@ impl DataLoader {
         batch_size: usize,
         num_workers: usize,
         shutdown: Arc<AtomicBool>,
+        draw_target: f32,
     ) -> Self {
         let (sender, receiver) = mpsc::sync_channel(num_workers * CHANNEL_BUFFER_MULTIPLIER);
 
@@ -41,6 +42,7 @@ impl DataLoader {
                     sender.clone(),
                     Arc::clone(&shutdown),
                     batch_size,
+                    draw_target,
                 )
             })
             .collect();
@@ -56,10 +58,11 @@ impl DataLoader {
         tx: mpsc::SyncSender<Batch>,
         shutdown: Arc<AtomicBool>,
         batch_size: usize,
+        draw_target: f32,
     ) -> thread::JoinHandle<()> {
         thread::spawn(move || {
             while !shutdown.load(Ordering::Relaxed) {
-                let batch = Self::collect_batch(&reader, batch_size, &shutdown);
+                let batch = Self::collect_batch(&reader, batch_size, &shutdown, draw_target);
 
                 if batch.scores.is_empty() || tx.send(batch).is_err() {
                     break;
@@ -68,7 +71,12 @@ impl DataLoader {
         })
     }
 
-    fn collect_batch(reader: &ShardReader, batch_size: usize, shutdown: &AtomicBool) -> Batch {
+    fn collect_batch(
+        reader: &ShardReader,
+        batch_size: usize,
+        shutdown: &AtomicBool,
+        draw_target: f32,
+    ) -> Batch {
         let mut stm_features = Vec::with_capacity(batch_size * NUM_FEATURES);
         let mut nstm_features = Vec::with_capacity(batch_size * NUM_FEATURES);
         let mut scores = Vec::with_capacity(batch_size);
@@ -82,7 +90,7 @@ impl DataLoader {
 
             match reader.next() {
                 Some(sample) => {
-                    if let Some(encoded) = sample.encode() {
+                    if let Some(encoded) = sample.encode(draw_target) {
                         stm_features.extend_from_slice(&encoded.stm_features);
                         nstm_features.extend_from_slice(&encoded.nstm_features);
                         scores.push(encoded.score);

--- a/training/src/bin/train/dataset/shard.rs
+++ b/training/src/bin/train/dataset/shard.rs
@@ -8,12 +8,19 @@ use nnue::encoding::{NUM_FEATURES, encode_board};
 use nnue::network::{FV_SCALE, output_bucket};
 use utils::board_metrics::BoardMetrics;
 
+#[derive(Debug, Clone, Copy)]
+pub enum Outcome {
+    WhiteWin,
+    Draw,
+    BlackWin,
+}
+
 /// A single sample from a shard file.
 #[derive(Debug, Clone)]
 pub struct Sample {
     pub fen: String,
     pub score: i16,
-    pub outcome: f32,
+    pub outcome: Outcome,
 }
 
 pub struct EncodedSample {
@@ -25,7 +32,7 @@ pub struct EncodedSample {
 }
 
 impl Sample {
-    pub fn encode(&self) -> Option<EncodedSample> {
+    pub fn encode(&self, draw_target: f32) -> Option<EncodedSample> {
         let board = Board::from_str(&self.fen).ok()?;
         let metrics = BoardMetrics::new(&board);
         let stm = board.side_to_move();
@@ -53,10 +60,14 @@ impl Sample {
         );
 
         let white_score = self.score as f32 / FV_SCALE;
-        let white_outcome = self.outcome;
-        let (score, outcome) = match stm {
-            Color::White => (white_score, white_outcome),
-            Color::Black => (-white_score, 1.0 - white_outcome),
+        let score = match stm {
+            Color::White => white_score,
+            Color::Black => -white_score,
+        };
+        let outcome = match (self.outcome, stm) {
+            (Outcome::Draw, _) => draw_target,
+            (Outcome::WhiteWin, Color::White) | (Outcome::BlackWin, Color::Black) => 1.0,
+            (Outcome::WhiteWin, Color::Black) | (Outcome::BlackWin, Color::White) => 0.0,
         };
 
         Some(EncodedSample {
@@ -113,11 +124,10 @@ fn parse_line(line: &str) -> Option<Sample> {
     let fen = parts.next()?.to_string();
     let score: i16 = parts.next()?.parse().ok()?;
 
-    // Map game outcomes to white perspective probabilities.
     let outcome = match parts.next()? {
-        "W" => 1.0,
-        "D" => 0.5,
-        "B" => 0.0,
+        "W" => Outcome::WhiteWin,
+        "D" => Outcome::Draw,
+        "B" => Outcome::BlackWin,
         _ => return None,
     };
 

--- a/training/src/bin/train/training/trainer.rs
+++ b/training/src/bin/train/training/trainer.rs
@@ -32,6 +32,7 @@ pub struct Trainer {
     lr_decay: f64,
     patience: u64,
     wdl: f64,
+    draw_target: f32,
     model_path: String,
 }
 
@@ -39,6 +40,7 @@ impl Trainer {
     pub fn new(args: &Args, model_path: &str) -> Result<Self, Box<dyn Error>> {
         let device = get_device()?;
         let wdl = args.wdl.clamp(0.0, 1.0);
+        let draw_target = args.draw_target.clamp(0.0, 1.0) as f32;
 
         let varmap = VarMap::new();
         let vs = VarBuilder::from_varmap(&varmap, DType::F32, &device);
@@ -62,6 +64,7 @@ impl Trainer {
             lr_decay: args.lr_decay,
             patience: args.patience,
             wdl,
+            draw_target,
             model_path: model_path.to_string(),
         })
     }
@@ -73,9 +76,10 @@ impl Trainer {
     ) -> Result<(), Box<dyn Error>> {
         log::info!("Using device: {:?}", self.device);
         log::info!(
-            "WDL blending: {:.0}% WDL / {:.0}% eval",
+            "WDL blending: {:.0}% WDL / {:.0}% eval, draw target {:.2}",
             self.wdl * 100.0,
-            (1.0 - self.wdl) * 100.0
+            (1.0 - self.wdl) * 100.0,
+            self.draw_target,
         );
 
         let mut metrics = MetricsTracker::new(self.patience);
@@ -119,7 +123,13 @@ impl Trainer {
         shutdown: &Arc<AtomicBool>,
     ) -> Result<Option<f32>, Box<dyn Error>> {
         let reader = Arc::new(ShardReader::new(dataset.train_path(), TRAIN_SHARDS)?);
-        let loader = DataLoader::new(reader, self.batch_size, self.workers, Arc::clone(shutdown));
+        let loader = DataLoader::new(
+            reader,
+            self.batch_size,
+            self.workers,
+            Arc::clone(shutdown),
+            self.draw_target,
+        );
 
         let num_batches = dataset.stats.train_samples.div_ceil(self.batch_size);
         let progress = TrainingProgressBar::new(num_batches)?;
@@ -164,6 +174,7 @@ impl Trainer {
             self.batch_size,
             self.workers,
             Arc::clone(shutdown),
+            self.draw_target,
         );
         let val_loss = evaluate(&self.network, val_loader, &self.device, self.wdl)?;
 
@@ -193,6 +204,7 @@ impl Trainer {
             self.batch_size,
             self.workers,
             Arc::clone(shutdown),
+            self.draw_target,
         );
         let test_loss = evaluate(&self.network, test_loader, &self.device, self.wdl)?;
         log::info!("Test Loss: {:.6}", test_loss);


### PR DESCRIPTION
## Summary

Currently, the WDL blends draws as 0.5, which is techniqually correct. But I was playing with the thought of what if draws were slightly negative. Would the engine then play more aggressively for a win? And not accept draws unless it has to?

So I made this proof of concept to find out. If it looks promising I will merge it and try re-doing the net with a new net using a slightly more agressive draw target.

Running som experiments in the comments.