### PR TITLE
feat: only do tt fail-high cutoffs in cut nodes

### DIFF
--- a/search/src/searcher/search.rs
+++ b/search/src/searcher/search.rs
@@ -255,19 +255,22 @@ impl Searcher {
             // missed tactics and can't safely prune the current search.
             //
             // Don't do TT cutoffs in PV nodes or during singular search.
+            let is_cut_node = node.is_cut();
             if !is_pv_node && singular.is_none() && tt.depth >= depth {
                 match tt.bound {
                     // Exact: previous search found true minimax value
                     Bound::Exact => {
-                        if let Some(m) = tt.best_move {
-                            self.pv_table.set_move(ply, m);
+                        if is_cut_node {
+                            if let Some(m) = tt.best_move {
+                                self.pv_table.set_move(ply, m);
+                            }
+                            return tt.value;
                         }
-                        return tt.value;
                     }
                     // Lower: previous search failed high (value >= beta), so value is at least this good
                     Bound::Lower => {
                         bounds.raise_alpha(tt.value);
-                        if bounds.is_cutoff(bounds.alpha) {
+                        if is_cut_node && bounds.is_cutoff(bounds.alpha) {
                             if let Some(m) = tt.best_move {
                                 self.pv_table.set_move(ply, m);
                             }

--- a/search/src/searcher/search.rs
+++ b/search/src/searcher/search.rs
@@ -269,12 +269,14 @@ impl Searcher {
                     }
                     // Lower: previous search failed high (value >= beta), so value is at least this good
                     Bound::Lower => {
-                        bounds.raise_alpha(tt.value);
-                        if is_cut_node && bounds.is_cutoff(bounds.alpha) {
-                            if let Some(m) = tt.best_move {
-                                self.pv_table.set_move(ply, m);
+                        if is_cut_node {
+                            bounds.raise_alpha(tt.value);
+                            if bounds.is_cutoff(bounds.alpha) {
+                                if let Some(m) = tt.best_move {
+                                    self.pv_table.set_move(ply, m);
+                                }
+                                return tt.value;
                             }
-                            return tt.value;
                         }
                     }
                     // Upper: previous search failed low (value <= alpha), so value is at most this bad


### PR DESCRIPTION
## Summary

I found that some engines only do fail-highs from TT in cut nodes, something Grail previously did not.

Not completely obvious to me why this gains ELO, but I yoinked it and SPRT looks pretty decent. So here we are.