### PR TITLE
nnue: june 2026

### DIFF
--- a/nnue/model.analysis.txt
+++ b/nnue/model.analysis.txt
@@ -1,231 +1,231 @@
 embedding (1152 -> 768) ============================================
-  weight:  mean 0.0514, median 0.0260, std 0.0900, max 1.2757, scale 3.49x, CoV 1.75, dead 3.2%
-  neurons: 768/768 active, row norm min 1.474 / mean 2.988 / max 11.302
-  bias:    mean -0.1643 (|b| mean 0.1901, max 0.5030)
+  weight:  mean 0.0666, median 0.0347, std 0.1145, max 2.1483, scale 4.52x, CoV 1.72, dead 3.1%
+  neurons: 768/768 active, row norm min 2.002 / mean 3.846 / max 9.783
+  bias:    mean -0.2165 (|b| mean 0.2501, max 0.6515)
 
   feature groups (column norms, x pieces):
-    pieces   ( 768 feats): norm 2.7996 (1.00x)
-    support  ( 128 feats): norm 1.0807 (0.39x)
-    space    ( 128 feats): norm 0.8342 (0.30x)
-    threats  ( 128 feats): norm 2.2957 (0.82x)
+    pieces   ( 768 feats): norm 3.5658 (1.00x)
+    support  ( 128 feats): norm 1.2720 (0.36x)
+    space    ( 128 feats): norm 1.1064 (0.31x)
+    threats  ( 128 feats): norm 2.8521 (0.80x)
 
   piece types (column norms, x pawn):
-    pawn   (128 feats): norm 2.2230 (1.00x)
-    knight (128 feats): norm 2.5107 (1.13x)
-    bishop (128 feats): norm 2.6156 (1.18x)
-    rook   (128 feats): norm 2.5157 (1.13x)
-    queen  (128 feats): norm 3.1370 (1.41x)
-    king   (128 feats): norm 3.7953 (1.71x)
+    pawn   (128 feats): norm 2.7851 (1.00x)
+    knight (128 feats): norm 3.1539 (1.13x)
+    bishop (128 feats): norm 3.3297 (1.20x)
+    rook   (128 feats): norm 3.2409 (1.16x)
+    queen  (128 feats): norm 3.9643 (1.42x)
+    king   (128 feats): norm 4.9210 (1.77x)
 
 piece heatmaps (col norm per square, us | them) ====================
-  pawn   us (0.000 - 3.402)        them (0.000 - 3.649)
+  pawn   us (0.000 - 4.592)        them (0.000 - 4.405)
       a  b  c  d  e  f  g  h       a  b  c  d  e  f  g  h
     8                            8                        
-    7 ██ ██ ██ ██ ██ ██ ██ ██    7 ▓▓ ██ ▓▓ ██ ▓▓ ██ ██ ██
-    6 ██ ▓▓ ██ ▓▓ ██ ██ ██ ██    6 ▓▓ ██ ██ ██ ██ ██ ▓▓ ▓▓
-    5 ▓▓ ██ ██ ██ ██ ██ ██ ▓▓    5 ▓▓ ▓▓ ██ ██ ██ ██ ██ ▓▓
-    4 ▓▓ ▓▓ ██ ██ ██ ██ ▓▓ ▓▓    4 ▓▓ ▓▓ ▓▓ ██ ██ ▓▓ ██ ▓▓
-    3 ▓▓ ▓▓ ██ ██ ██ ██ ██ ▓▓    3 ▓▓ ██ ▓▓ ██ ██ ██ ██ ██
-    2 ▓▓ ██ ██ ▓▓ ██ ██ ██ ▓▓    2 ██ ██ ██ ██ ██ ██ ██ ██
+    7 ██ ██ ██ ██ ██ ██ ██ ██    7 ▓▓ ██ ▓▓ ██ ██ ██ ██ ██
+    6 ██ ▓▓ ▓▓ ██ ██ ██ ██ ▓▓    6 ▓▓ ▓▓ ██ ▓▓ ██ ██ ██ ▓▓
+    5 ▓▓ ▓▓ ▓▓ ██ ██ ▓▓ ██ ▓▓    5 ▓▓ ▓▓ ██ ▓▓ ██ ▓▓ ▓▓ ▓▓
+    4 ▓▓ ▓▓ ██ ██ ██ ██ ▓▓ ▓▓    4 ▓▓ ▓▓ ▓▓ ██ ██ ██ ▓▓ ▓▓
+    3 ▓▓ ▓▓ ██ ██ ██ ██ ██ ▓▓    3 ██ ██ ██ ██ ██ ██ ██ ██
+    2 ▓▓ ▓▓ ▓▓ ▓▓ ▓▓ ██ ▓▓ ▓▓    2 ██ ██ ██ ██ ██ ██ ██ ██
     1                            1                        
 
-  knight us (2.165 - 2.868)        them (2.190 - 2.987)
+  knight us (2.815 - 3.687)        them (2.709 - 3.625)
       a  b  c  d  e  f  g  h       a  b  c  d  e  f  g  h
-    8 ▒▒ ▒▒ ▒▒ ▓▓ ▒▒ ██ ██ ▓▓    8 ▓▓ ▓▓ ░░       ░░ ▒▒ ▓▓
-    7 ▒▒ ▒▒ ▓▓ ░░ ▓▓ ▓▓ ▒▒ ██    7 ░░       ░░ ░░ ░░    ░░
-    6 ▒▒ ░░ ▓▓ ▓▓ ▒▒ ▓▓ ▒▒ ▓▓    6 ░░ ░░ ▒▒ ░░ ▓▓    ░░   
-    5    ░░ ▒▒ ░░ ▒▒ ▓▓ ▓▓ ▒▒    5 ▓▓ ░░ ██ ░░ ▓▓ ▒▒ ░░ ░░
-    4       ▒▒ ▒▒ ░░ ░░ ▒▒ ▓▓    4 ░░    ▒▒ ▓▓ ░░ ░░ ▒▒ ▒▒
-    3    ░░    ░░ ░░ ▒▒ ░░ ░░    3 ▒▒ ░░       ░░ ▒▒ ░░ ██
-    2 ░░    ░░ ▒▒ ▒▒ ▒▒ ░░ ▒▒    2 ░░ ▒▒ ▓▓ ▒▒ ▒▒ ▒▒ ▒▒ ▓▓
-    1 ██ ░░ ░░ ▒▒ ▒▒ ░░ ██ ██    1 ▓▓ ▓▓ ▒▒    ▒▒ ▒▒ ▓▓ ██
+    8 ▒▒ ▒▒    ▒▒ ▓▓ ▒▒ ██ ██    8 ██ ▓▓ ▓▓ ░░ ░░ ▒▒ ██ ██
+    7 ▒▒ ░░ ░░ ▓▓ ▒▒ ▓▓ ░░ ▓▓    7 ▒▒ ░░ ░░ ▓▓    ░░ ▒▒ ▒▒
+    6 ▒▒ ░░ ▓▓    ░░ ▒▒ ▓▓ ▓▓    6 ░░    ▒▒ ▒▒ ░░ ▒▒ ▒▒ ▓▓
+    5 ░░ ▒▒    ▓▓ ▒▒    ░░ ▓▓    5 ▒▒ ░░    ░░ ▒▒ ▓▓ ░░ ▓▓
+    4 ░░    ▓▓ ░░ ▒▒ ░░ ▒▒ ░░    4       ▓▓ ░░ ▒▒ ▒▒ ▓▓   
+    3 ░░    ░░ ▒▒ ██ ▒▒    ░░    3 ░░       ▒▒ ░░ ▒▒ ▒▒ ▓▓
+    2 ░░ ░░ ░░    ▓▓ ░░ ░░       2 ▓▓ ▒▒ ▓▓ ░░ ▒▒ ▒▒ ░░ ▓▓
+    1 ▒▒ ██    ▒▒ ░░ ░░ ░░ ▒▒    1 ▒▒ ░░ ▒▒ ▒▒ ░░ ▒▒ ▒▒ ▓▓
 
-  bishop us (2.273 - 3.145)        them (2.350 - 3.190)
+  bishop us (2.782 - 3.790)        them (2.985 - 4.168)
       a  b  c  d  e  f  g  h       a  b  c  d  e  f  g  h
-    8 ░░ ░░ ░░ ▒▒ ░░ ▒▒ ▒▒ ▒▒    8 ▒▒ ▓▓ ▓▓ ▒▒    ░░ ▓▓ ██
-    7 ▒▒ ░░ ░░ ░░ ▒▒ ░░ ▒▒ ▒▒    7 ▒▒    ▒▒ ░░ ░░    ░░ ░░
-    6          ░░ ░░ ▓▓ ▒▒ ▒▒    6    ▒▒ ░░ ▒▒ ░░ ░░ ░░ ░░
-    5       ░░ ░░ ░░ ░░    ░░    5       ▒▒ ░░ ▒▒ ▒▒ ░░   
-    4    ░░ ▒▒ ▒▒ ░░    ░░ ░░    4       ░░ ▒▒ ▓▓ ░░ ▒▒   
-    3    ░░ ░░ ░░    ▒▒ ▒▒ ▒▒    3       ░░ ░░ ▒▒    ▒▒ ░░
-    2 ▒▒ ░░    ░░ ▒▒ ░░ ▓▓ ▓▓    2 ▒▒    ░░ ░░    ▓▓ ░░ ▓▓
-    1 ▓▓ ▒▒    ░░ ░░ ▒▒ ▓▓ ██    1 ▒▒ ░░ ░░ ░░ ░░ ░░ ▒▒ ▒▒
+    8 ▓▓ ░░ ░░ ▒▒ ░░ ▒▒ ▒▒ ▓▓    8 ▓▓ ██ ▓▓ ░░ ▒▒ ▒▒ ▓▓ ██
+    7 ▓▓ ▒▒ ░░ ░░ ▒▒ ░░ ▒▒ ██    7 ▒▒ ▒▒ ░░ ░░ ░░ ░░ ██ ░░
+    6    ░░ ░░ ▒▒ ▒▒ ▓▓ ░░ ▓▓    6 ░░ ░░ ░░ ▒▒ ░░ ░░ ░░ ▒▒
+    5 ░░    ░░ ▒▒ ██ ░░ ▒▒ ░░    5 ░░ ░░ ░░ ░░ ▓▓ ▒▒ ▒▒   
+    4 ░░    ▓▓ ▓▓    ░░    ▒▒    4    ░░ ░░ ▓▓ ░░ ▒▒ ░░ ░░
+    3    ▓▓ ▒▒ ░░ ▓▓ ░░ ▓▓       3       ░░    ░░ ░░ ░░   
+    2 ▓▓ ▒▒ ░░ ▒▒ ░░ ░░ ░░ ▓▓    2 ▒▒ ░░    ░░ ░░ ▒▒    ▒▒
+    1 ██ ▒▒    ░░ ▒▒    ▓▓ ██    1 ▒▒    ▒▒    ░░    ░░ ░░
 
-  rook   us (2.237 - 3.113)        them (2.187 - 2.783)
+  rook   us (2.903 - 3.807)        them (2.787 - 3.872)
       a  b  c  d  e  f  g  h       a  b  c  d  e  f  g  h
-    8 ▒▒ ▒▒ ▒▒ ▒▒ ▒▒ ▓▓ ▓▓ ▓▓    8 ▒▒ ▓▓ ░░ ░░ ░░ ░░ ▓▓ ▓▓
-    7 ▒▒ ▒▒ ▒▒ ▒▒ ▓▓ ▒▒ ▓▓ ██    7 ▒▒ ▒▒    ░░    ░░ ▒▒ ▒▒
-    6 ░░ ░░ ░░ ▒▒ ░░ ▒▒ ▒▒ ▒▒    6    ░░ ░░    ░░    ░░   
-    5    ░░ ░░       ░░ ░░ ▒▒    5       ░░    ▒▒ ░░ ▒▒ ░░
-    4       ░░ ░░    ░░ ░░ ▒▒    4       ░░    ░░ ░░ ▒▒ ░░
-    3 ░░       ░░    ░░ ▓▓ ▒▒    3 ░░ ▒▒ ▒▒ ░░ ░░ ▒▒ ██ ██
-    2 ░░          ░░ ░░ ▒▒ ▒▒    2 ▒▒ ██ ▓▓ ▒▒ ██ ██ ██ ▓▓
-    1 ██ ░░ ░░ ▒▒ ░░ ▒▒ ▓▓ ▓▓    1 ▓▓ ▓▓ ▓▓ ▒▒ ▓▓ ▓▓ ██ ██
+    8 ▒▒ ▒▒ ░░ ▒▒ ▒▒ ▒▒ ▓▓ ▓▓    8 ██ ░░ ░░ ░░    ░░ ██ ██
+    7 ░░ ▓▓ ▒▒ ▓▓ ▓▓ ▓▓ ██ ██    7 ▒▒ ░░ ░░ ░░ ░░ ░░ ▒▒ ▓▓
+    6 ▒▒ ▒▒ ░░ ▒▒ ░░ ▒▒ ▓▓ ▒▒    6    ░░ ░░          ░░ ░░
+    5 ░░ ░░       ▒▒ ░░ ▓▓ ▒▒    5 ░░                ░░ ▒▒
+    4          ░░    ░░ ▒▒ ░░    4 ░░ ░░ ░░ ░░    ░░ ░░ ▒▒
+    3          ░░ ░░ ░░ ▒▒ ░░    3 ▒▒ ░░ ░░ ░░ ░░ ░░ ▒▒ ▒▒
+    2 ░░    ░░ ░░ ░░ ▒▒ ▒▒ ░░    2 ▒▒ ▒▒ ▒▒ ▒▒ ▒▒ ▒▒ ▓▓ ▒▒
+    1 ▓▓ ▒▒ ░░ ▒▒ ▒▒ ▒▒ ▒▒ ▓▓    1 ▒▒ ░░ ▒▒ ░░ ▒▒ ▒▒ ▒▒ ▒▒
 
-  queen  us (2.778 - 3.525)        them (2.871 - 3.656)
+  queen  us (3.391 - 4.556)        them (3.647 - 4.458)
       a  b  c  d  e  f  g  h       a  b  c  d  e  f  g  h
-    8 ██ ░░ ▒▒ ▒▒ ▒▒ ▓▓ ██ ██    8       ░░ ░░       ░░ ▒▒
-    7 ▒▒ ░░ ▒▒ ▒▒ ▓▓ ▓▓ ▓▓ ██    7 ░░    ░░          ░░ ▒▒
-    6 ▒▒ ▒▒ ▒▒ ░░ ▓▓ ▓▓ ▓▓ ▓▓    6 ░░ ░░ ░░    ░░    ░░ ░░
-    5 ▒▒ ▒▒ ▒▒ ░░ ░░ ▒▒ ░░ ▒▒    5 ▒▒ ░░       ░░    ▒▒ ▒▒
-    4 ░░    ░░ ░░    ░░ ░░ ▒▒    4 ░░ ░░ ░░ ░░ ░░ ░░ ▒▒ ▒▒
-    3 ░░ ░░          ▒▒ ░░ ░░    3 ░░ ▒▒ ▒▒ ░░ ░░ ▒▒ ▓▓ ██
-    2 ▒▒          ░░ ░░ ░░ ▒▒    2 ▒▒ ▓▓ ▒▒ ░░ ▒▒ ▓▓ ██ ▓▓
-    1 ▒▒    ░░ ░░ ░░ ░░ ░░ ▓▓    1 ▓▓ ▒▒ ░░ ▒▒ ▓▓ ▓▓ ▓▓ ██
+    8 ▓▓ ▒▒ ▒▒ ▓▓ ▓▓ ▓▓ ██ ██    8 ░░ ░░    ▒▒       ░░ ▓▓
+    7 ░░ ▒▒ ▒▒ ▒▒ ▒▒ ▓▓ ██ ██    7 ░░    ▓▓          ░░ ▒▒
+    6 ░░ ░░ ░░ ▒▒ ▒▒ ▓▓ ▓▓ ▓▓    6 ░░ ▒▒ ░░             ▒▒
+    5 ░░ ░░    ░░ ▒▒ ░░ ▒▒ ▒▒    5 ░░    ░░    ░░    ░░ ░░
+    4 ░░ ░░ ░░ ░░ ░░ ▒▒ ▒▒ ▓▓    4 ▒▒ ░░ ▒▒ ▒▒ ░░ ░░ ░░ ░░
+    3 ░░ ▒▒    ▒▒ ░░ ▒▒ ▒▒ ▒▒    3 ▒▒ ▒▒ ▓▓ ▒▒ ▒▒ ▒▒ ▓▓ ▒▒
+    2 ▒▒ ░░ ░░ ░░ ▒▒ ▒▒ ▒▒ ▒▒    2 ▓▓ ██ ▒▒ ░░ ▓▓ ▓▓ ▓▓ ██
+    1 ▓▓ ░░ ░░ ░░ ░░    ░░ ▒▒    1 ██ ▓▓ ██ ██ ▓▓ ▒▒ ██ ██
 
-  king   us (3.384 - 4.814)        them (3.188 - 4.565)
+  king   us (4.268 - 5.939)        them (3.972 - 6.078)
       a  b  c  d  e  f  g  h       a  b  c  d  e  f  g  h
-    8 ░░ ░░          ░░ ░░ ▒▒    8 ██ ██ ▓▓ ░░ ▒▒ ▒▒ ▒▒ ▒▒
-    7 ▒▒ ▒▒ ░░ ░░    ░░ ░░ ▒▒    7 ▓▓ ▓▓ ▒▒ ░░    ░░ ▒▒ ▒▒
-    6 ░░ ░░             ▒▒ ░░    6 ▓▓ ▒▒ ░░ ▒▒       ░░ ░░
-    5 ░░ ░░ ░░          ░░ ░░    5 ▒▒ ▒▒ ░░               
-    4    ░░ ░░ ░░          ░░    4 ▒▒ ▒▒             ░░ ░░
-    3 ▓▓ ▒▒ ▒▒ ░░       ░░ ▒▒    3 ▒▒ ▒▒ ░░ ░░ ░░    ▒▒ ░░
-    2 ▓▓ ▓▓ ▓▓ ▒▒ ░░ ░░ ░░ ▒▒    2 ▒▒ ▒▒ ▒▒ ░░ ░░ ▒▒ ▒▒ ░░
-    1 ██ ██ ▓▓ ▒▒ ▓▓ ░░ ▒▒ ▓▓    1 ▓▓ ▒▒ ▒▒    ░░ ░░ ░░ ▒▒
+    8 ▒▒ ▓▓ ░░ ░░ ░░ ░░ ░░ ▒▒    8 ██ ██ ██ ▒▒ ▓▓ ▒▒ ▓▓ ▓▓
+    7 ▒▒ ██ ▒▒ ▒▒ ░░ ▒▒ ▓▓ ▓▓    7 ██ ▓▓ ▓▓ ▒▒ ░░    ▒▒ ▒▒
+    6 ▒▒ ▒▒ ▒▒ ░░ ░░ ▒▒ ▒▒ ▒▒    6 ▓▓ ▒▒ ▒▒ ░░       ░░ ▒▒
+    5 ▒▒ ▒▒ ░░       ░░ ▒▒ ░░    5 ▒▒ ▒▒ ░░          ░░ ░░
+    4 ░░ ▒▒ ░░ ░░       ░░ ░░    4 ▒▒ ▒▒    ░░       ░░ ▒▒
+    3 ▓▓ ▒▒ ▒▒ ▒▒ ░░    ░░ ▒▒    3 ░░ ▒▒ ░░ ░░ ░░ ░░ ▒▒ ▒▒
+    2 ██ ▓▓ ▓▓ ░░ ░░    ░░ ▓▓    2 ▒▒ ▒▒ ░░ ░░ ░░ ░░ ▒▒ ▒▒
+    1 ██ ██ ▓▓ ▒▒ ▒▒ ░░ ▒▒ ▒▒    1 ▒▒ ▒▒ ░░    ░░ ░░ ▒▒ ▒▒
 
 bucket 0 ===========================================================
   hidden1 (1536 -> 16):
-    weight:  mean 0.0629, median 0.0319, std 0.1103, max 1.2148, scale 4.93x, CoV 1.75, rel 0.03x, dead 18.9%
-    neurons: 13/16 active, row norm min 0.000 / mean 3.799 / max 7.108
-    bias:    mean +0.0112 (|b| mean 0.0213, max 0.0614)
+    weight:  mean 0.0673, median 0.0331, std 0.1229, max 1.6284, scale 5.27x, CoV 1.83, rel 0.04x, dead 25.1%
+    neurons: 12/16 active, row norm min 0.000 / mean 4.106 / max 7.593
+    bias:    mean +0.0258 (|b| mean 0.0332, max 0.1426)
   hidden2 (16 -> 16):
-    weight:  mean 0.4754, median 0.2538, std 0.7261, max 2.9546, scale 3.80x, CoV 1.53, rel 0.25x, dead 18.8%
-    neurons: 16/16 active, row norm min 2.117 / mean 2.919 / max 4.205
-    bias:    mean +0.0378 (|b| mean 0.0724, max 0.1835)
+    weight:  mean 0.3121, median 0.1493, std 0.6056, max 4.0176, scale 2.50x, CoV 1.94, rel 0.20x, dead 25.0%
+    neurons: 16/16 active, row norm min 1.002 / mean 2.274 / max 4.085
+    bias:    mean +0.0477 (|b| mean 0.0822, max 0.2479)
   output (16 -> 1):
-    weight:  mean 1.8662, median 1.3051, std 2.0958, max 4.3170, scale 14.93x, CoV 1.12, rel 1.00x, dead 0.0%
-    neurons: 1/1 active, row norm min 8.916 / mean 8.916 / max 8.916
-    bias:    mean +0.2061 (|b| mean 0.2061, max 0.2061)
+    weight:  mean 1.5271, median 1.1674, std 1.7342, max 3.9973, scale 12.22x, CoV 1.14, rel 1.00x, dead 0.0%
+    neurons: 1/1 active, row norm min 7.339 / mean 7.339 / max 7.339
+    bias:    mean +0.0097 (|b| mean 0.0097, max 0.0097)
 
 bucket 1 ===========================================================
   hidden1 (1536 -> 16):
-    weight:  mean 0.0554, median 0.0290, std 0.0983, max 1.0751, scale 4.34x, CoV 1.77, rel 0.03x, dead 18.8%
-    neurons: 13/16 active, row norm min 0.000 / mean 3.434 / max 5.759
-    bias:    mean +0.0209 (|b| mean 0.0366, max 0.1143)
+    weight:  mean 0.0507, median 0.0161, std 0.1027, max 0.9847, scale 3.97x, CoV 2.03, rel 0.03x, dead 37.6%
+    neurons: 10/16 active, row norm min 0.000 / mean 3.160 / max 6.638
+    bias:    mean +0.0324 (|b| mean 0.0392, max 0.1753)
   hidden2 (16 -> 16):
-    weight:  mean 0.3257, median 0.1796, std 0.5526, max 4.5289, scale 2.61x, CoV 1.70, rel 0.19x, dead 18.8%
-    neurons: 15/16 active, row norm min 0.971 / mean 2.027 / max 5.314
-    bias:    mean +0.0282 (|b| mean 0.0825, max 0.1905)
+    weight:  mean 0.2194, median 0.0911, std 0.4530, max 3.9017, scale 1.76x, CoV 2.06, rel 0.14x, dead 37.5%
+    neurons: 12/16 active, row norm min 0.769 / mean 1.546 / max 4.631
+    bias:    mean +0.0211 (|b| mean 0.1399, max 0.2783)
   output (16 -> 1):
-    weight:  mean 1.7297, median 1.2861, std 1.9209, max 3.3089, scale 13.84x, CoV 1.11, rel 1.00x, dead 0.0%
-    neurons: 1/1 active, row norm min 7.725 / mean 7.725 / max 7.725
-    bias:    mean +0.0178 (|b| mean 0.0178, max 0.0178)
+    weight:  mean 1.5563, median 1.4092, std 1.8155, max 3.9974, scale 12.45x, CoV 1.17, rel 1.00x, dead 0.0%
+    neurons: 1/1 active, row norm min 7.265 / mean 7.265 / max 7.265
+    bias:    mean -0.0457 (|b| mean 0.0457, max 0.0457)
 
 bucket 2 ===========================================================
   hidden1 (1536 -> 16):
-    weight:  mean 0.0488, median 0.0191, std 0.0963, max 0.9644, scale 3.83x, CoV 1.97, rel 0.03x, dead 31.5%
-    neurons: 11/16 active, row norm min 0.000 / mean 3.099 / max 5.842
-    bias:    mean +0.0242 (|b| mean 0.0342, max 0.1630)
+    weight:  mean 0.0412, median 0.0000, std 0.0942, max 1.0685, scale 3.23x, CoV 2.29, rel 0.03x, dead 50.1%
+    neurons: 8/16 active, row norm min 0.000 / mean 2.593 / max 6.307
+    bias:    mean +0.0320 (|b| mean 0.0359, max 0.2371)
   hidden2 (16 -> 16):
-    weight:  mean 0.2905, median 0.1192, std 0.5171, max 3.0926, scale 2.32x, CoV 1.78, rel 0.16x, dead 31.2%
-    neurons: 16/16 active, row norm min 1.188 / mean 1.959 / max 3.468
-    bias:    mean +0.0241 (|b| mean 0.1026, max 0.3550)
+    weight:  mean 0.1616, median 0.0000, std 0.3527, max 2.8074, scale 1.29x, CoV 2.18, rel 0.12x, dead 56.2%
+    neurons: 12/16 active, row norm min 0.000 / mean 1.246 / max 2.926
+    bias:    mean +0.0143 (|b| mean 0.1144, max 0.4842)
   output (16 -> 1):
-    weight:  mean 1.7975, median 1.7864, std 1.9311, max 3.6786, scale 14.38x, CoV 1.07, rel 1.00x, dead 0.0%
-    neurons: 1/1 active, row norm min 8.198 / mean 8.198 / max 8.198
-    bias:    mean +0.1017 (|b| mean 0.1017, max 0.1017)
+    weight:  mean 1.3769, median 1.2869, std 1.4594, max 3.0053, scale 11.02x, CoV 1.06, rel 1.00x, dead 12.5%
+    neurons: 1/1 active, row norm min 6.665 / mean 6.665 / max 6.665
+    bias:    mean +0.0773 (|b| mean 0.0773, max 0.0773)
 
 bucket 3 ===========================================================
   hidden1 (1536 -> 16):
-    weight:  mean 0.0292, median 0.0000, std 0.0771, max 1.0417, scale 2.29x, CoV 2.65, rel 0.02x, dead 62.7%
-    neurons: 6/16 active, row norm min 0.000 / mean 1.819 / max 6.659
-    bias:    mean +0.0225 (|b| mean 0.0233, max 0.2382)
+    weight:  mean 0.0349, median 0.0000, std 0.1028, max 1.4176, scale 2.74x, CoV 2.95, rel 0.03x, dead 68.8%
+    neurons: 5/16 active, row norm min 0.000 / mean 2.236 / max 8.798
+    bias:    mean +0.0305 (|b| mean 0.0346, max 0.2183)
   hidden2 (16 -> 16):
-    weight:  mean 0.1358, median 0.0000, std 0.3377, max 3.3472, scale 1.09x, CoV 2.49, rel 0.10x, dead 67.2%
-    neurons: 9/16 active, row norm min 0.000 / mean 1.129 / max 3.450
-    bias:    mean +0.0266 (|b| mean 0.0864, max 0.2724)
+    weight:  mean 0.0842, median 0.0000, std 0.2129, max 1.4116, scale 0.67x, CoV 2.53, rel 0.08x, dead 74.6%
+    neurons: 3/16 active, row norm min 0.000 / mean 0.741 / max 1.598
+    bias:    mean -0.0283 (|b| mean 0.2077, max 0.6716)
   output (16 -> 1):
-    weight:  mean 1.4264, median 1.2427, std 1.6224, max 3.0722, scale 11.41x, CoV 1.14, rel 1.00x, dead 12.5%
-    neurons: 1/1 active, row norm min 6.668 / mean 6.668 / max 6.668
-    bias:    mean +0.0104 (|b| mean 0.0104, max 0.0104)
+    weight:  mean 1.0536, median 1.1396, std 1.2255, max 2.0601, scale 8.43x, CoV 1.16, rel 1.00x, dead 18.8%
+    neurons: 1/1 active, row norm min 4.980 / mean 4.980 / max 4.980
+    bias:    mean +0.1326 (|b| mean 0.1326, max 0.1326)
 
 bucket 4 ===========================================================
   hidden1 (1536 -> 16):
-    weight:  mean 0.0207, median 0.0000, std 0.0765, max 1.3187, scale 1.62x, CoV 3.70, rel 0.01x, dead 75.4%
-    neurons: 4/16 active, row norm min 0.000 / mean 1.416 / max 9.012
-    bias:    mean +0.0350 (|b| mean 0.0350, max 0.1951)
+    weight:  mean 0.0260, median 0.0000, std 0.0794, max 1.3972, scale 2.04x, CoV 3.05, rel 0.02x, dead 69.0%
+    neurons: 5/16 active, row norm min 0.000 / mean 1.724 / max 6.451
+    bias:    mean +0.0495 (|b| mean 0.0495, max 0.2559)
   hidden2 (16 -> 16):
-    weight:  mean 0.0847, median 0.0000, std 0.2103, max 1.4149, scale 0.68x, CoV 2.48, rel 0.05x, dead 75.0%
-    neurons: 3/16 active, row norm min 0.359 / mean 0.782 / max 1.634
-    bias:    mean -0.0703 (|b| mean 0.2022, max 0.4675)
+    weight:  mean 0.1045, median 0.0000, std 0.2739, max 2.2397, scale 0.84x, CoV 2.62, rel 0.08x, dead 68.8%
+    neurons: 5/16 active, row norm min 0.483 / mean 0.978 / max 2.279
+    bias:    mean -0.0538 (|b| mean 0.2215, max 0.7452)
   output (16 -> 1):
-    weight:  mean 1.7261, median 1.7789, std 1.8537, max 3.2139, scale 13.81x, CoV 1.07, rel 1.00x, dead 0.0%
-    neurons: 1/1 active, row norm min 7.417 / mean 7.417 / max 7.417
-    bias:    mean +0.2662 (|b| mean 0.2662, max 0.2662)
+    weight:  mean 1.3510, median 1.3921, std 1.4743, max 2.5559, scale 10.81x, CoV 1.09, rel 1.00x, dead 0.0%
+    neurons: 1/1 active, row norm min 5.898 / mean 5.898 / max 5.898
+    bias:    mean +0.1669 (|b| mean 0.1669, max 0.1669)
 
 bucket 5 ===========================================================
   hidden1 (1536 -> 16):
-    weight:  mean 0.0237, median 0.0000, std 0.0757, max 1.2017, scale 1.86x, CoV 3.19, rel 0.02x, dead 69.6%
-    neurons: 5/16 active, row norm min 0.000 / mean 1.589 / max 8.142
-    bias:    mean +0.0328 (|b| mean 0.0328, max 0.1796)
+    weight:  mean 0.0233, median 0.0000, std 0.0820, max 1.7161, scale 1.82x, CoV 3.52, rel 0.02x, dead 75.4%
+    neurons: 4/16 active, row norm min 0.000 / mean 1.592 / max 7.491
+    bias:    mean +0.0380 (|b| mean 0.0380, max 0.2581)
   hidden2 (16 -> 16):
-    weight:  mean 0.0936, median 0.0000, std 0.2191, max 1.2855, scale 0.75x, CoV 2.34, rel 0.07x, dead 68.8%
-    neurons: 3/16 active, row norm min 0.436 / mean 0.833 / max 1.591
-    bias:    mean -0.0732 (|b| mean 0.1249, max 0.3476)
+    weight:  mean 0.0734, median 0.0000, std 0.1942, max 1.3741, scale 0.59x, CoV 2.65, rel 0.05x, dead 75.0%
+    neurons: 3/16 active, row norm min 0.283 / mean 0.690 / max 1.651
+    bias:    mean +0.0381 (|b| mean 0.2236, max 0.5739)
   output (16 -> 1):
-    weight:  mean 1.3237, median 1.2675, std 1.4510, max 2.3698, scale 10.59x, CoV 1.10, rel 1.00x, dead 0.0%
-    neurons: 1/1 active, row norm min 5.804 / mean 5.804 / max 5.804
-    bias:    mean -0.0274 (|b| mean 0.0274, max 0.0274)
+    weight:  mean 1.3959, median 1.3694, std 1.5232, max 2.7466, scale 11.17x, CoV 1.09, rel 1.00x, dead 0.0%
+    neurons: 1/1 active, row norm min 6.217 / mean 6.217 / max 6.217
+    bias:    mean +0.0730 (|b| mean 0.0730, max 0.0730)
 
 bucket 6 ===========================================================
   hidden1 (1536 -> 16):
-    weight:  mean 0.0134, median 0.0000, std 0.0528, max 1.5287, scale 1.05x, CoV 3.93, rel 0.01x, dead 82.1%
-    neurons: 3/16 active, row norm min 0.000 / mean 0.888 / max 5.612
-    bias:    mean +0.0097 (|b| mean 0.0171, max 0.1566)
+    weight:  mean 0.0114, median 0.0000, std 0.0528, max 1.3353, scale 0.89x, CoV 4.64, rel 0.01x, dead 88.0%
+    neurons: 2/16 active, row norm min 0.000 / mean 0.729 / max 6.385
+    bias:    mean +0.0175 (|b| mean 0.0175, max 0.1857)
   hidden2 (16 -> 16):
-    weight:  mean 0.0720, median 0.0000, std 0.2363, max 1.4219, scale 0.58x, CoV 3.28, rel 0.07x, dead 85.9%
-    neurons: 5/16 active, row norm min 0.000 / mean 0.764 / max 1.940
-    bias:    mean -0.0227 (|b| mean 0.0888, max 0.2928)
+    weight:  mean 0.0359, median 0.0000, std 0.1280, max 0.7930, scale 0.29x, CoV 3.56, rel 0.03x, dead 89.1%
+    neurons: 0/16 active, row norm min 0.000 / mean 0.457 / max 0.909
+    bias:    mean -0.0013 (|b| mean 0.1469, max 0.2308)
   output (16 -> 1):
-    weight:  mean 1.0463, median 1.1881, std 1.2651, max 2.6073, scale 8.37x, CoV 1.21, rel 1.00x, dead 25.0%
-    neurons: 1/1 active, row norm min 5.131 / mean 5.131 / max 5.131
-    bias:    mean -0.0641 (|b| mean 0.0641, max 0.0641)
+    weight:  mean 1.4070, median 1.4678, std 1.6563, max 3.1139, scale 11.26x, CoV 1.18, rel 1.00x, dead 12.5%
+    neurons: 1/1 active, row norm min 6.637 / mean 6.637 / max 6.637
+    bias:    mean -0.0109 (|b| mean 0.0109, max 0.0109)
 
 bucket 7 ===========================================================
   hidden1 (1536 -> 16):
-    weight:  mean 0.0069, median 0.0000, std 0.0451, max 2.2461, scale 0.54x, CoV 6.52, rel 0.01x, dead 94.3%
-    neurons: 1/16 active, row norm min 0.000 / mean 0.442 / max 7.079
-    bias:    mean +0.0100 (|b| mean 0.0100, max 0.1604)
+    weight:  mean 0.0124, median 0.0000, std 0.0595, max 2.2105, scale 0.97x, CoV 4.79, rel 0.02x, dead 88.5%
+    neurons: 2/16 active, row norm min 0.000 / mean 0.823 / max 6.951
+    bias:    mean +0.0100 (|b| mean 0.0128, max 0.1823)
   hidden2 (16 -> 16):
-    weight:  mean 0.0203, median 0.0000, std 0.1964, max 2.9705, scale 0.16x, CoV 9.69, rel 0.02x, dead 97.7%
-    neurons: 1/16 active, row norm min 0.000 / mean 0.324 / max 2.971
-    bias:    mean -0.0226 (|b| mean 0.0935, max 0.5216)
+    weight:  mean 0.0364, median 0.0000, std 0.1661, max 1.6197, scale 0.29x, CoV 4.56, rel 0.05x, dead 92.2%
+    neurons: 2/16 active, row norm min 0.000 / mean 0.460 / max 1.696
+    bias:    mean -0.0054 (|b| mean 0.0807, max 0.1862)
   output (16 -> 1):
-    weight:  mean 0.8875, median 0.0000, std 1.5585, max 3.9994, scale 7.10x, CoV 1.76, rel 1.00x, dead 62.5%
-    neurons: 1/1 active, row norm min 6.260 / mean 6.260 / max 6.260
-    bias:    mean +0.1160 (|b| mean 0.1160, max 0.1160)
+    weight:  mean 0.7773, median 0.7151, std 1.0451, max 2.3913, scale 6.22x, CoV 1.34, rel 1.00x, dead 37.5%
+    neurons: 1/1 active, row norm min 4.482 / mean 4.482 / max 4.482
+    bias:    mean -0.1356 (|b| mean 0.1356, max 0.1356)
 
 summary (across 8 buckets) =========================================
   scale (x init):
-    hidden1: avg 2.56x (range 0.54x - 4.93x)
-    hidden2: avg 1.50x (range 0.16x - 3.80x)
-    output : avg 11.80x (range 7.10x - 14.93x)
+    hidden1: avg 2.62x (range 0.89x - 5.27x)
+    hidden2: avg 1.03x (range 0.29x - 2.50x)
+    output : avg 10.44x (range 6.22x - 12.45x)
 
   dead weight fraction:
-    hidden1: avg 56.7% (range 18.8% - 94.3%)
-    hidden2: avg 57.9% (range 18.8% - 97.7%)
-    output : avg 12.5% (range 0.0% - 62.5%)
+    hidden1: avg 62.8% (range 25.1% - 88.5%)
+    hidden2: avg 64.8% (range 25.0% - 92.2%)
+    output : avg 10.2% (range 0.0% - 37.5%)
 
   active neurons (of 16):
-    hidden1: avg 7.0 (range 1.0 - 13.0)
-    hidden2: avg 8.5 (range 1.0 - 16.0)
+    hidden1: avg 6.0 (range 2.0 - 12.0)
+    hidden2: avg 6.6 (range 0.0 - 16.0)
 
   CoV (std / mean |W|):
-    hidden1: avg 3.19 (range 1.75 - 6.52)
-    hidden2: avg 3.16 (range 1.53 - 9.69)
-    output : avg 1.20 (range 1.07 - 1.76)
+    hidden1: avg 3.14 (range 1.83 - 4.79)
+    hidden2: avg 2.76 (range 1.94 - 4.56)
+    output : avg 1.15 (range 1.06 - 1.34)
 
   rel (x bucket output mean |W|):
-    hidden1: avg 0.02x (range 0.01x - 0.03x)
-    hidden2: avg 0.11x (range 0.02x - 0.25x)
+    hidden1: avg 0.02x (range 0.01x - 0.04x)
+    hidden2: avg 0.09x (range 0.03x - 0.20x)
 
 bucket output similarity (cosine) ==================================
          b1    b2    b3    b4    b5    b6    b7
-  b0   0.02  0.28 -0.23  0.42  0.11 -0.35  0.17
-  b1        -0.09 -0.26 -0.23 -0.06  0.21 -0.16
-  b2              -0.18 -0.06  0.11  0.07 -0.14
-  b3                    -0.34  0.34  0.10  0.16
-  b4                           0.09 -0.24  0.04
-  b5                                -0.02  0.01
-  b6                                       0.06
+  b0  -0.14  0.12  0.56  0.10  0.41 -0.27 -0.09
+  b1         0.20  0.13 -0.26  0.16  0.01 -0.14
+  b2               0.03 -0.44  0.13  0.23 -0.49
+  b3                     0.04  0.43 -0.43 -0.13
+  b4                           0.17 -0.34  0.46
+  b5                                -0.17 -0.31
+  b6                                      -0.29

--- a/nnue/model.analysis.txt
+++ b/nnue/model.analysis.txt
@@ -1,206 +1,206 @@
 embedding (1152 -> 768) ============================================
-  weight:  mean 0.0666, median 0.0347, std 0.1145, max 2.1483, scale 4.52x, CoV 1.72, dead 3.1%
-  neurons: 768/768 active, row norm min 2.002 / mean 3.846 / max 9.783
-  bias:    mean -0.2165 (|b| mean 0.2501, max 0.6515)
+  weight:  mean 0.0457, median 0.0227, std 0.0806, max 1.5548, scale 3.10x, CoV 1.76, dead 3.2%
+  neurons: 768/768 active, row norm min 1.376 / mean 2.692 / max 7.298
+  bias:    mean -0.1532 (|b| mean 0.1774, max 0.4632)
 
   feature groups (column norms, x pieces):
-    pieces   ( 768 feats): norm 3.5658 (1.00x)
-    support  ( 128 feats): norm 1.2720 (0.36x)
-    space    ( 128 feats): norm 1.1064 (0.31x)
-    threats  ( 128 feats): norm 2.8521 (0.80x)
+    pieces   ( 768 feats): norm 2.5040 (1.00x)
+    support  ( 128 feats): norm 0.8585 (0.34x)
+    space    ( 128 feats): norm 0.7542 (0.30x)
+    threats  ( 128 feats): norm 2.0263 (0.81x)
 
   piece types (column norms, x pawn):
-    pawn   (128 feats): norm 2.7851 (1.00x)
-    knight (128 feats): norm 3.1539 (1.13x)
-    bishop (128 feats): norm 3.3297 (1.20x)
-    rook   (128 feats): norm 3.2409 (1.16x)
-    queen  (128 feats): norm 3.9643 (1.42x)
-    king   (128 feats): norm 4.9210 (1.77x)
+    pawn   (128 feats): norm 1.8939 (1.00x)
+    knight (128 feats): norm 2.1606 (1.14x)
+    bishop (128 feats): norm 2.3001 (1.21x)
+    rook   (128 feats): norm 2.2656 (1.20x)
+    queen  (128 feats): norm 2.8463 (1.50x)
+    king   (128 feats): norm 3.5577 (1.88x)
 
 piece heatmaps (col norm per square, us | them) ====================
-  pawn   us (0.000 - 4.592)        them (0.000 - 4.405)
+  pawn   us (0.000 - 3.123)        them (0.000 - 2.947)
       a  b  c  d  e  f  g  h       a  b  c  d  e  f  g  h
     8                            8                        
-    7 ██ ██ ██ ██ ██ ██ ██ ██    7 ▓▓ ██ ▓▓ ██ ██ ██ ██ ██
-    6 ██ ▓▓ ▓▓ ██ ██ ██ ██ ▓▓    6 ▓▓ ▓▓ ██ ▓▓ ██ ██ ██ ▓▓
+    7 ██ ██ ██ ██ ██ ██ ██ ██    7 ▓▓ ██ ██ ██ ██ ██ ██ ██
+    6 ██ ▓▓ ██ ██ ██ ██ ██ ▓▓    6 ▓▓ ▓▓ ██ ██ ██ ██ ██ ▓▓
     5 ▓▓ ▓▓ ▓▓ ██ ██ ▓▓ ██ ▓▓    5 ▓▓ ▓▓ ██ ▓▓ ██ ▓▓ ▓▓ ▓▓
-    4 ▓▓ ▓▓ ██ ██ ██ ██ ▓▓ ▓▓    4 ▓▓ ▓▓ ▓▓ ██ ██ ██ ▓▓ ▓▓
-    3 ▓▓ ▓▓ ██ ██ ██ ██ ██ ▓▓    3 ██ ██ ██ ██ ██ ██ ██ ██
+    4 ▓▓ ▓▓ ██ ██ ██ ██ ▓▓ ▓▓    4 ▓▓ ▓▓ ▓▓ ██ ██ ██ ██ ▓▓
+    3 ▓▓ ▓▓ ██ ██ ██ ██ ▓▓ ▓▓    3 ██ ██ ██ ██ ██ ██ ██ ██
     2 ▓▓ ▓▓ ▓▓ ▓▓ ▓▓ ██ ▓▓ ▓▓    2 ██ ██ ██ ██ ██ ██ ██ ██
     1                            1                        
 
-  knight us (2.815 - 3.687)        them (2.709 - 3.625)
+  knight us (1.887 - 2.535)        them (1.849 - 2.568)
       a  b  c  d  e  f  g  h       a  b  c  d  e  f  g  h
-    8 ▒▒ ▒▒    ▒▒ ▓▓ ▒▒ ██ ██    8 ██ ▓▓ ▓▓ ░░ ░░ ▒▒ ██ ██
+    8 ▒▒ ▒▒ ░░ ▒▒ ▓▓ ▒▒ ██ ██    8 ██ ▒▒ ▒▒ ░░ ░░ ▒▒ ██ ██
     7 ▒▒ ░░ ░░ ▓▓ ▒▒ ▓▓ ░░ ▓▓    7 ▒▒ ░░ ░░ ▓▓    ░░ ▒▒ ▒▒
-    6 ▒▒ ░░ ▓▓    ░░ ▒▒ ▓▓ ▓▓    6 ░░    ▒▒ ▒▒ ░░ ▒▒ ▒▒ ▓▓
-    5 ░░ ▒▒    ▓▓ ▒▒    ░░ ▓▓    5 ▒▒ ░░    ░░ ▒▒ ▓▓ ░░ ▓▓
-    4 ░░    ▓▓ ░░ ▒▒ ░░ ▒▒ ░░    4       ▓▓ ░░ ▒▒ ▒▒ ▓▓   
-    3 ░░    ░░ ▒▒ ██ ▒▒    ░░    3 ░░       ▒▒ ░░ ▒▒ ▒▒ ▓▓
-    2 ░░ ░░ ░░    ▓▓ ░░ ░░       2 ▓▓ ▒▒ ▓▓ ░░ ▒▒ ▒▒ ░░ ▓▓
-    1 ▒▒ ██    ▒▒ ░░ ░░ ░░ ▒▒    1 ▒▒ ░░ ▒▒ ▒▒ ░░ ▒▒ ▒▒ ▓▓
+    6 ▒▒ ░░ ▓▓ ░░ ▒▒ ░░ ▓▓ ▓▓    6 ░░ ░░ ▒▒ ░░ ░░ ▒▒ ▒▒ ▓▓
+    5 ░░ ▒▒    ▓▓ ▓▓ ░░ ░░ ▓▓    5 ░░ ░░    ░░ ▒▒ ▒▒ ░░ ▒▒
+    4 ▒▒    ▓▓ ▒▒ ▒▒ ░░ ░░ ░░    4       ▒▒    ░░ ▒▒ ▒▒   
+    3 ░░    ░░ ▒▒ ██ ▒▒ ░░ ░░    3 ░░       ▒▒ ░░ ▒▒ ▒▒ ▒▒
+    2 ▒▒ ░░ ░░    ▓▓ ░░ ░░       2 ▒▒ ░░ ▒▒ ░░ ▒▒ ▒▒ ░░ ▒▒
+    1 ▓▓ ██    ▒▒ ▒▒    ░░ ▒▒    1 ░░ ░░ ▒▒ ▒▒ ░░ ▒▒ ▒▒ ▒▒
 
-  bishop us (2.782 - 3.790)        them (2.985 - 4.168)
+  bishop us (1.904 - 2.618)        them (2.037 - 2.924)
       a  b  c  d  e  f  g  h       a  b  c  d  e  f  g  h
-    8 ▓▓ ░░ ░░ ▒▒ ░░ ▒▒ ▒▒ ▓▓    8 ▓▓ ██ ▓▓ ░░ ▒▒ ▒▒ ▓▓ ██
-    7 ▓▓ ▒▒ ░░ ░░ ▒▒ ░░ ▒▒ ██    7 ▒▒ ▒▒ ░░ ░░ ░░ ░░ ██ ░░
-    6    ░░ ░░ ▒▒ ▒▒ ▓▓ ░░ ▓▓    6 ░░ ░░ ░░ ▒▒ ░░ ░░ ░░ ▒▒
-    5 ░░    ░░ ▒▒ ██ ░░ ▒▒ ░░    5 ░░ ░░ ░░ ░░ ▓▓ ▒▒ ▒▒   
-    4 ░░    ▓▓ ▓▓    ░░    ▒▒    4    ░░ ░░ ▓▓ ░░ ▒▒ ░░ ░░
-    3    ▓▓ ▒▒ ░░ ▓▓ ░░ ▓▓       3       ░░    ░░ ░░ ░░   
-    2 ▓▓ ▒▒ ░░ ▒▒ ░░ ░░ ░░ ▓▓    2 ▒▒ ░░    ░░ ░░ ▒▒    ▒▒
-    1 ██ ▒▒    ░░ ▒▒    ▓▓ ██    1 ▒▒    ▒▒    ░░    ░░ ░░
+    8 ▒▒ ▒▒ ░░ ▒▒ ░░ ▒▒ ▒▒ ▓▓    8 ▓▓ ██ ▓▓ ▒▒ ░░ ▒▒ ██ ██
+    7 ▓▓ ▒▒ ▒▒ ░░ ▒▒ ▒▒ ▓▓ ██    7 ▒▒ ▒▒ ▒▒ ░░ ░░ ░░ ▓▓ ░░
+    6    ░░ ░░ ▒▒ ▓▓ ██ ▒▒ ▒▒    6 ░░ ░░ ░░ ░░ ░░ ░░ ░░ ▒▒
+    5 ░░    ░░ ░░ ██ ░░ ▓▓ ░░    5 ░░ ░░ ░░ ░░ ▓▓ ▒▒ ▒▒   
+    4       ▓▓ ▒▒    ░░ ░░ ▒▒    4    ░░ ▒▒ ▓▓ ░░ ▒▒ ░░ ░░
+    3    ▒▒ ░░    ▒▒ ░░ ▓▓       3       ░░    ░░ ░░ ░░ ░░
+    2 ▒▒ ░░ ░░ ▒▒ ░░ ░░ ░░ ▒▒    2 ░░ ░░ ░░ ▒▒ ░░ ▒▒ ░░ ▒▒
+    1 ██ ░░    ░░ ▒▒    ▓▓ ██    1 ▒▒ ░░ ▒▒ ░░ ░░    ▒▒ ░░
 
-  rook   us (2.903 - 3.807)        them (2.787 - 3.872)
+  rook   us (1.995 - 2.655)        them (1.917 - 2.729)
       a  b  c  d  e  f  g  h       a  b  c  d  e  f  g  h
-    8 ▒▒ ▒▒ ░░ ▒▒ ▒▒ ▒▒ ▓▓ ▓▓    8 ██ ░░ ░░ ░░    ░░ ██ ██
-    7 ░░ ▓▓ ▒▒ ▓▓ ▓▓ ▓▓ ██ ██    7 ▒▒ ░░ ░░ ░░ ░░ ░░ ▒▒ ▓▓
-    6 ▒▒ ▒▒ ░░ ▒▒ ░░ ▒▒ ▓▓ ▒▒    6    ░░ ░░          ░░ ░░
-    5 ░░ ░░       ▒▒ ░░ ▓▓ ▒▒    5 ░░                ░░ ▒▒
-    4          ░░    ░░ ▒▒ ░░    4 ░░ ░░ ░░ ░░    ░░ ░░ ▒▒
-    3          ░░ ░░ ░░ ▒▒ ░░    3 ▒▒ ░░ ░░ ░░ ░░ ░░ ▒▒ ▒▒
-    2 ░░    ░░ ░░ ░░ ▒▒ ▒▒ ░░    2 ▒▒ ▒▒ ▒▒ ▒▒ ▒▒ ▒▒ ▓▓ ▒▒
-    1 ▓▓ ▒▒ ░░ ▒▒ ▒▒ ▒▒ ▒▒ ▓▓    1 ▒▒ ░░ ▒▒ ░░ ▒▒ ▒▒ ▒▒ ▒▒
+    8 ▓▓ ▒▒ ░░ ▓▓ ▒▒ ▓▓ ▓▓ ██    8 ██ ▒▒ ░░ ▒▒    ▒▒ ▓▓ ██
+    7 ░░ ▓▓ ▒▒ ██ ▓▓ ▓▓ ██ ██    7 ▒▒ ░░ ░░ ░░ ░░ ░░ ▒▒ ▓▓
+    6 ░░ ▒▒ ▒▒ ▒▒ ▒▒ ▒▒ ▓▓ ▒▒    6    ░░             ░░ ░░
+    5 ░░ ░░ ░░ ░░ ▒▒ ▒▒ ▓▓ ▒▒    5 ░░ ░░             ░░ ▒▒
+    4          ▒▒    ▒▒ ▒▒ ░░    4 ░░ ░░ ░░ ░░    ░░ ░░ ▒▒
+    3    ░░    ░░ ░░    ▒▒ ░░    3 ▒▒ ░░ ░░ ░░ ▒▒ ░░ ▒▒ ▒▒
+    2 ▒▒    ░░ ░░ ░░ ▒▒ ▒▒ ░░    2 ▒▒ ░░ ▒▒ ▒▒ ▒▒ ▒▒ ▓▓ ▒▒
+    1 ▓▓ ▒▒ ▒▒ ▒▒ ▓▓ ▓▓ ▓▓ ▓▓    1 ▒▒ ▒▒ ▒▒ ▒▒ ▒▒ ▒▒ ▒▒ ▒▒
 
-  queen  us (3.391 - 4.556)        them (3.647 - 4.458)
+  queen  us (2.469 - 3.308)        them (2.588 - 3.237)
       a  b  c  d  e  f  g  h       a  b  c  d  e  f  g  h
-    8 ▓▓ ▒▒ ▒▒ ▓▓ ▓▓ ▓▓ ██ ██    8 ░░ ░░    ▒▒       ░░ ▓▓
-    7 ░░ ▒▒ ▒▒ ▒▒ ▒▒ ▓▓ ██ ██    7 ░░    ▓▓          ░░ ▒▒
-    6 ░░ ░░ ░░ ▒▒ ▒▒ ▓▓ ▓▓ ▓▓    6 ░░ ▒▒ ░░             ▒▒
-    5 ░░ ░░    ░░ ▒▒ ░░ ▒▒ ▒▒    5 ░░    ░░    ░░    ░░ ░░
-    4 ░░ ░░ ░░ ░░ ░░ ▒▒ ▒▒ ▓▓    4 ▒▒ ░░ ▒▒ ▒▒ ░░ ░░ ░░ ░░
-    3 ░░ ▒▒    ▒▒ ░░ ▒▒ ▒▒ ▒▒    3 ▒▒ ▒▒ ▓▓ ▒▒ ▒▒ ▒▒ ▓▓ ▒▒
-    2 ▒▒ ░░ ░░ ░░ ▒▒ ▒▒ ▒▒ ▒▒    2 ▓▓ ██ ▒▒ ░░ ▓▓ ▓▓ ▓▓ ██
-    1 ▓▓ ░░ ░░ ░░ ░░    ░░ ▒▒    1 ██ ▓▓ ██ ██ ▓▓ ▒▒ ██ ██
+    8 ▒▒ ▒▒ ▒▒ ▓▓ ▓▓ ██ ██ ██    8 ▒▒ ░░ ░░ ▒▒       ░░ ▓▓
+    7 ░░ ▒▒ ▒▒ ▒▒ ▒▒ ▓▓ ██ ██    7 ░░    ▒▒          ░░ ▒▒
+    6 ░░    ░░ ░░ ▒▒ ▓▓ ▓▓ ▓▓    6 ░░ ▒▒ ░░          ░░ ░░
+    5 ░░       ░░ ▒▒ ░░ ▒▒ ▒▒    5 ░░    ░░    ░░    ░░ ░░
+    4       ░░ ░░ ░░ ░░ ░░ ▒▒    4 ▒▒ ▒▒ ▒▒ ▒▒ ░░ ░░ ░░ ░░
+    3 ░░ ▒▒    ▒▒ ░░ ░░ ░░ ░░    3 ▒▒ ▒▒ ▓▓ ▒▒ ▓▓ ▒▒ ▓▓ ▒▒
+    2 ░░    ░░    ░░ ░░ ▒▒ ▒▒    2 ▓▓ ██ ▒▒ ▒▒ ▓▓ ▓▓ ██ ██
+    1 ▒▒ ░░ ░░    ░░    ░░ ░░    1 ██ ▓▓ ██ ▓▓ ▓▓ ▒▒ ██ ██
 
-  king   us (4.268 - 5.939)        them (3.972 - 6.078)
+  king   us (3.104 - 4.270)        them (2.816 - 4.355)
       a  b  c  d  e  f  g  h       a  b  c  d  e  f  g  h
-    8 ▒▒ ▓▓ ░░ ░░ ░░ ░░ ░░ ▒▒    8 ██ ██ ██ ▒▒ ▓▓ ▒▒ ▓▓ ▓▓
-    7 ▒▒ ██ ▒▒ ▒▒ ░░ ▒▒ ▓▓ ▓▓    7 ██ ▓▓ ▓▓ ▒▒ ░░    ▒▒ ▒▒
-    6 ▒▒ ▒▒ ▒▒ ░░ ░░ ▒▒ ▒▒ ▒▒    6 ▓▓ ▒▒ ▒▒ ░░       ░░ ▒▒
-    5 ▒▒ ▒▒ ░░       ░░ ▒▒ ░░    5 ▒▒ ▒▒ ░░          ░░ ░░
-    4 ░░ ▒▒ ░░ ░░       ░░ ░░    4 ▒▒ ▒▒    ░░       ░░ ▒▒
-    3 ▓▓ ▒▒ ▒▒ ▒▒ ░░    ░░ ▒▒    3 ░░ ▒▒ ░░ ░░ ░░ ░░ ▒▒ ▒▒
-    2 ██ ▓▓ ▓▓ ░░ ░░    ░░ ▓▓    2 ▒▒ ▒▒ ░░ ░░ ░░ ░░ ▒▒ ▒▒
-    1 ██ ██ ▓▓ ▒▒ ▒▒ ░░ ▒▒ ▒▒    1 ▒▒ ▒▒ ░░    ░░ ░░ ▒▒ ▒▒
+    8 ▓▓ ▓▓ ▒▒ ░░ ░░ ▒▒ ▒▒ ▒▒    8 ██ ██ ██ ▓▓ ▓▓ ▒▒ ▓▓ ▓▓
+    7 ▒▒ ██ ▒▒ ▒▒ ░░ ▒▒ ▓▓ ▓▓    7 ▓▓ ▓▓ ▓▓ ▒▒ ░░ ░░ ▒▒ ▒▒
+    6 ▒▒ ▒▒ ▒▒ ░░ ░░ ▒▒ ▒▒ ▒▒    6 ▓▓ ▒▒ ▒▒ ▒▒       ░░ ▒▒
+    5 ▒▒ ▒▒ ▒▒    ░░ ░░ ▒▒ ░░    5 ▒▒ ▒▒ ░░          ░░ ░░
+    4 ░░ ▒▒ ▒▒ ░░          ░░    4 ▒▒ ▒▒    ░░       ░░ ▒▒
+    3 ▓▓ ▓▓ ▒▒ ▒▒       ░░ ▒▒    3 ▒▒ ▒▒ ▒▒ ░░ ░░ ░░ ▒▒ ▒▒
+    2 ██ ▓▓ ▓▓ ░░ ░░    ░░ ▒▒    2 ▒▒ ▒▒ ░░ ░░ ░░ ▒▒ ▒▒ ▒▒
+    1 ██ ██ ▓▓ ▒▒ ▒▒ ░░ ▒▒ ▒▒    1 ▒▒ ▒▒ ░░ ░░ ▒▒ ▒▒ ▒▒ ▒▒
 
 bucket 0 ===========================================================
   hidden1 (1536 -> 16):
-    weight:  mean 0.0673, median 0.0331, std 0.1229, max 1.6284, scale 5.27x, CoV 1.83, rel 0.04x, dead 25.1%
-    neurons: 12/16 active, row norm min 0.000 / mean 4.106 / max 7.593
-    bias:    mean +0.0258 (|b| mean 0.0332, max 0.1426)
+    weight:  mean 0.0612, median 0.0292, std 0.1129, max 1.4063, scale 4.80x, CoV 1.84, rel 0.03x, dead 25.1%
+    neurons: 12/16 active, row norm min 0.000 / mean 3.748 / max 7.171
+    bias:    mean +0.0161 (|b| mean 0.0224, max 0.0707)
   hidden2 (16 -> 16):
-    weight:  mean 0.3121, median 0.1493, std 0.6056, max 4.0176, scale 2.50x, CoV 1.94, rel 0.20x, dead 25.0%
-    neurons: 16/16 active, row norm min 1.002 / mean 2.274 / max 4.085
-    bias:    mean +0.0477 (|b| mean 0.0822, max 0.2479)
+    weight:  mean 0.3843, median 0.1691, std 0.7500, max 4.4300, scale 3.07x, CoV 1.95, rel 0.19x, dead 25.0%
+    neurons: 16/16 active, row norm min 1.151 / mean 2.807 / max 4.524
+    bias:    mean +0.0442 (|b| mean 0.0697, max 0.2241)
   output (16 -> 1):
-    weight:  mean 1.5271, median 1.1674, std 1.7342, max 3.9973, scale 12.22x, CoV 1.14, rel 1.00x, dead 0.0%
-    neurons: 1/1 active, row norm min 7.339 / mean 7.339 / max 7.339
-    bias:    mean +0.0097 (|b| mean 0.0097, max 0.0097)
+    weight:  mean 2.0753, median 1.6123, std 2.3685, max 5.6254, scale 16.60x, CoV 1.14, rel 1.00x, dead 0.0%
+    neurons: 1/1 active, row norm min 10.022 / mean 10.022 / max 10.022
+    bias:    mean +0.0305 (|b| mean 0.0305, max 0.0305)
 
 bucket 1 ===========================================================
   hidden1 (1536 -> 16):
-    weight:  mean 0.0507, median 0.0161, std 0.1027, max 0.9847, scale 3.97x, CoV 2.03, rel 0.03x, dead 37.6%
-    neurons: 10/16 active, row norm min 0.000 / mean 3.160 / max 6.638
-    bias:    mean +0.0324 (|b| mean 0.0392, max 0.1753)
+    weight:  mean 0.0458, median 0.0147, std 0.0924, max 0.9691, scale 3.59x, CoV 2.02, rel 0.02x, dead 37.6%
+    neurons: 10/16 active, row norm min 0.000 / mean 2.836 / max 6.128
+    bias:    mean +0.0236 (|b| mean 0.0276, max 0.1242)
   hidden2 (16 -> 16):
-    weight:  mean 0.2194, median 0.0911, std 0.4530, max 3.9017, scale 1.76x, CoV 2.06, rel 0.14x, dead 37.5%
-    neurons: 12/16 active, row norm min 0.769 / mean 1.546 / max 4.631
-    bias:    mean +0.0211 (|b| mean 0.1399, max 0.2783)
+    weight:  mean 0.2677, median 0.0937, std 0.5445, max 4.6763, scale 2.14x, CoV 2.03, rel 0.13x, dead 37.5%
+    neurons: 15/16 active, row norm min 0.966 / mean 1.875 / max 5.582
+    bias:    mean +0.0299 (|b| mean 0.1114, max 0.2184)
   output (16 -> 1):
-    weight:  mean 1.5563, median 1.4092, std 1.8155, max 3.9974, scale 12.45x, CoV 1.17, rel 1.00x, dead 0.0%
-    neurons: 1/1 active, row norm min 7.265 / mean 7.265 / max 7.265
-    bias:    mean -0.0457 (|b| mean 0.0457, max 0.0457)
+    weight:  mean 2.1122, median 1.8708, std 2.4724, max 5.3971, scale 16.90x, CoV 1.17, rel 1.00x, dead 0.0%
+    neurons: 1/1 active, row norm min 9.895 / mean 9.895 / max 9.895
+    bias:    mean -0.1019 (|b| mean 0.1019, max 0.1019)
 
 bucket 2 ===========================================================
   hidden1 (1536 -> 16):
-    weight:  mean 0.0412, median 0.0000, std 0.0942, max 1.0685, scale 3.23x, CoV 2.29, rel 0.03x, dead 50.1%
-    neurons: 8/16 active, row norm min 0.000 / mean 2.593 / max 6.307
-    bias:    mean +0.0320 (|b| mean 0.0359, max 0.2371)
+    weight:  mean 0.0364, median 0.0000, std 0.0829, max 0.9421, scale 2.86x, CoV 2.27, rel 0.02x, dead 50.1%
+    neurons: 8/16 active, row norm min 0.000 / mean 2.270 / max 5.653
+    bias:    mean +0.0258 (|b| mean 0.0259, max 0.1669)
   hidden2 (16 -> 16):
-    weight:  mean 0.1616, median 0.0000, std 0.3527, max 2.8074, scale 1.29x, CoV 2.18, rel 0.12x, dead 56.2%
-    neurons: 12/16 active, row norm min 0.000 / mean 1.246 / max 2.926
-    bias:    mean +0.0143 (|b| mean 0.1144, max 0.4842)
+    weight:  mean 0.1965, median 0.0000, std 0.4110, max 3.0059, scale 1.57x, CoV 2.09, rel 0.10x, dead 56.2%
+    neurons: 14/16 active, row norm min 0.000 / mean 1.467 / max 3.203
+    bias:    mean +0.0241 (|b| mean 0.0985, max 0.4298)
   output (16 -> 1):
-    weight:  mean 1.3769, median 1.2869, std 1.4594, max 3.0053, scale 11.02x, CoV 1.06, rel 1.00x, dead 12.5%
-    neurons: 1/1 active, row norm min 6.665 / mean 6.665 / max 6.665
-    bias:    mean +0.0773 (|b| mean 0.0773, max 0.0773)
+    weight:  mean 1.8968, median 1.7794, std 1.9998, max 4.1762, scale 15.17x, CoV 1.05, rel 1.00x, dead 12.5%
+    neurons: 1/1 active, row norm min 9.127 / mean 9.127 / max 9.127
+    bias:    mean +0.0855 (|b| mean 0.0855, max 0.0855)
 
 bucket 3 ===========================================================
   hidden1 (1536 -> 16):
-    weight:  mean 0.0349, median 0.0000, std 0.1028, max 1.4176, scale 2.74x, CoV 2.95, rel 0.03x, dead 68.8%
-    neurons: 5/16 active, row norm min 0.000 / mean 2.236 / max 8.798
-    bias:    mean +0.0305 (|b| mean 0.0346, max 0.2183)
+    weight:  mean 0.0346, median 0.0000, std 0.1003, max 1.2976, scale 2.71x, CoV 2.90, rel 0.03x, dead 68.8%
+    neurons: 5/16 active, row norm min 0.000 / mean 2.174 / max 8.769
+    bias:    mean +0.0266 (|b| mean 0.0266, max 0.1765)
   hidden2 (16 -> 16):
-    weight:  mean 0.0842, median 0.0000, std 0.2129, max 1.4116, scale 0.67x, CoV 2.53, rel 0.08x, dead 74.6%
-    neurons: 3/16 active, row norm min 0.000 / mean 0.741 / max 1.598
-    bias:    mean -0.0283 (|b| mean 0.2077, max 0.6716)
+    weight:  mean 0.1026, median 0.0000, std 0.2591, max 1.7290, scale 0.82x, CoV 2.53, rel 0.08x, dead 74.6%
+    neurons: 9/16 active, row norm min 0.000 / mean 0.903 / max 1.956
+    bias:    mean -0.0126 (|b| mean 0.1963, max 0.5552)
   output (16 -> 1):
-    weight:  mean 1.0536, median 1.1396, std 1.2255, max 2.0601, scale 8.43x, CoV 1.16, rel 1.00x, dead 18.8%
-    neurons: 1/1 active, row norm min 4.980 / mean 4.980 / max 4.980
-    bias:    mean +0.1326 (|b| mean 0.1326, max 0.1326)
+    weight:  mean 1.3236, median 1.4385, std 1.5311, max 2.5002, scale 10.59x, CoV 1.16, rel 1.00x, dead 18.8%
+    neurons: 1/1 active, row norm min 6.229 / mean 6.229 / max 6.229
+    bias:    mean +0.1364 (|b| mean 0.1364, max 0.1364)
 
 bucket 4 ===========================================================
   hidden1 (1536 -> 16):
-    weight:  mean 0.0260, median 0.0000, std 0.0794, max 1.3972, scale 2.04x, CoV 3.05, rel 0.02x, dead 69.0%
-    neurons: 5/16 active, row norm min 0.000 / mean 1.724 / max 6.451
-    bias:    mean +0.0495 (|b| mean 0.0495, max 0.2559)
+    weight:  mean 0.0232, median 0.0000, std 0.0696, max 1.2504, scale 1.82x, CoV 3.00, rel 0.01x, dead 69.0%
+    neurons: 5/16 active, row norm min 0.000 / mean 1.505 / max 5.859
+    bias:    mean +0.0336 (|b| mean 0.0336, max 0.1519)
   hidden2 (16 -> 16):
-    weight:  mean 0.1045, median 0.0000, std 0.2739, max 2.2397, scale 0.84x, CoV 2.62, rel 0.08x, dead 68.8%
-    neurons: 5/16 active, row norm min 0.483 / mean 0.978 / max 2.279
-    bias:    mean -0.0538 (|b| mean 0.2215, max 0.7452)
+    weight:  mean 0.1256, median 0.0000, std 0.3078, max 2.2176, scale 1.00x, CoV 2.45, rel 0.07x, dead 68.8%
+    neurons: 9/16 active, row norm min 0.610 / mean 1.138 / max 2.439
+    bias:    mean -0.0250 (|b| mean 0.1859, max 0.6893)
   output (16 -> 1):
-    weight:  mean 1.3510, median 1.3921, std 1.4743, max 2.5559, scale 10.81x, CoV 1.09, rel 1.00x, dead 0.0%
-    neurons: 1/1 active, row norm min 5.898 / mean 5.898 / max 5.898
-    bias:    mean +0.1669 (|b| mean 0.1669, max 0.1669)
+    weight:  mean 1.7720, median 1.7980, std 1.9259, max 3.4568, scale 14.18x, CoV 1.09, rel 1.00x, dead 0.0%
+    neurons: 1/1 active, row norm min 7.704 / mean 7.704 / max 7.704
+    bias:    mean +0.0954 (|b| mean 0.0954, max 0.0954)
 
 bucket 5 ===========================================================
   hidden1 (1536 -> 16):
-    weight:  mean 0.0233, median 0.0000, std 0.0820, max 1.7161, scale 1.82x, CoV 3.52, rel 0.02x, dead 75.4%
-    neurons: 4/16 active, row norm min 0.000 / mean 1.592 / max 7.491
-    bias:    mean +0.0380 (|b| mean 0.0380, max 0.2581)
+    weight:  mean 0.0213, median 0.0000, std 0.0730, max 1.3428, scale 1.67x, CoV 3.43, rel 0.01x, dead 75.4%
+    neurons: 4/16 active, row norm min 0.000 / mean 1.421 / max 6.394
+    bias:    mean +0.0283 (|b| mean 0.0283, max 0.1716)
   hidden2 (16 -> 16):
-    weight:  mean 0.0734, median 0.0000, std 0.1942, max 1.3741, scale 0.59x, CoV 2.65, rel 0.05x, dead 75.0%
-    neurons: 3/16 active, row norm min 0.283 / mean 0.690 / max 1.651
-    bias:    mean +0.0381 (|b| mean 0.2236, max 0.5739)
+    weight:  mean 0.0905, median 0.0000, std 0.2380, max 1.8415, scale 0.72x, CoV 2.63, rel 0.05x, dead 75.0%
+    neurons: 3/16 active, row norm min 0.394 / mean 0.848 / max 2.146
+    bias:    mean +0.0512 (|b| mean 0.2032, max 0.4915)
   output (16 -> 1):
-    weight:  mean 1.3959, median 1.3694, std 1.5232, max 2.7466, scale 11.17x, CoV 1.09, rel 1.00x, dead 0.0%
-    neurons: 1/1 active, row norm min 6.217 / mean 6.217 / max 6.217
-    bias:    mean +0.0730 (|b| mean 0.0730, max 0.0730)
+    weight:  mean 1.8470, median 1.7085, std 2.0143, max 3.5341, scale 14.78x, CoV 1.09, rel 1.00x, dead 0.0%
+    neurons: 1/1 active, row norm min 8.186 / mean 8.186 / max 8.186
+    bias:    mean +0.0633 (|b| mean 0.0633, max 0.0633)
 
 bucket 6 ===========================================================
   hidden1 (1536 -> 16):
-    weight:  mean 0.0114, median 0.0000, std 0.0528, max 1.3353, scale 0.89x, CoV 4.64, rel 0.01x, dead 88.0%
-    neurons: 2/16 active, row norm min 0.000 / mean 0.729 / max 6.385
-    bias:    mean +0.0175 (|b| mean 0.0175, max 0.1857)
+    weight:  mean 0.0102, median 0.0000, std 0.0466, max 1.1846, scale 0.80x, CoV 4.57, rel 0.01x, dead 88.0%
+    neurons: 2/16 active, row norm min 0.000 / mean 0.641 / max 5.706
+    bias:    mean +0.0110 (|b| mean 0.0110, max 0.1159)
   hidden2 (16 -> 16):
-    weight:  mean 0.0359, median 0.0000, std 0.1280, max 0.7930, scale 0.29x, CoV 3.56, rel 0.03x, dead 89.1%
-    neurons: 0/16 active, row norm min 0.000 / mean 0.457 / max 0.909
-    bias:    mean -0.0013 (|b| mean 0.1469, max 0.2308)
+    weight:  mean 0.0470, median 0.0000, std 0.1666, max 1.0683, scale 0.38x, CoV 3.55, rel 0.03x, dead 89.1%
+    neurons: 2/16 active, row norm min 0.000 / mean 0.590 / max 1.217
+    bias:    mean +0.0014 (|b| mean 0.1120, max 0.1951)
   output (16 -> 1):
-    weight:  mean 1.4070, median 1.4678, std 1.6563, max 3.1139, scale 11.26x, CoV 1.18, rel 1.00x, dead 12.5%
-    neurons: 1/1 active, row norm min 6.637 / mean 6.637 / max 6.637
-    bias:    mean -0.0109 (|b| mean 0.0109, max 0.0109)
+    weight:  mean 1.8581, median 1.9620, std 2.1684, max 4.0627, scale 14.86x, CoV 1.17, rel 1.00x, dead 12.5%
+    neurons: 1/1 active, row norm min 8.681 / mean 8.681 / max 8.681
+    bias:    mean -0.0136 (|b| mean 0.0136, max 0.0136)
 
 bucket 7 ===========================================================
   hidden1 (1536 -> 16):
-    weight:  mean 0.0124, median 0.0000, std 0.0595, max 2.2105, scale 0.97x, CoV 4.79, rel 0.02x, dead 88.5%
-    neurons: 2/16 active, row norm min 0.000 / mean 0.823 / max 6.951
-    bias:    mean +0.0100 (|b| mean 0.0128, max 0.1823)
+    weight:  mean 0.0111, median 0.0000, std 0.0520, max 1.8573, scale 0.87x, CoV 4.69, rel 0.01x, dead 88.5%
+    neurons: 2/16 active, row norm min 0.000 / mean 0.720 / max 5.924
+    bias:    mean +0.0060 (|b| mean 0.0095, max 0.1240)
   hidden2 (16 -> 16):
-    weight:  mean 0.0364, median 0.0000, std 0.1661, max 1.6197, scale 0.29x, CoV 4.56, rel 0.05x, dead 92.2%
-    neurons: 2/16 active, row norm min 0.000 / mean 0.460 / max 1.696
-    bias:    mean -0.0054 (|b| mean 0.0807, max 0.1862)
+    weight:  mean 0.0509, median 0.0000, std 0.2397, max 2.4780, scale 0.41x, CoV 4.71, rel 0.05x, dead 92.2%
+    neurons: 4/16 active, row norm min 0.000 / mean 0.641 / max 2.564
+    bias:    mean +0.0002 (|b| mean 0.0599, max 0.1611)
   output (16 -> 1):
-    weight:  mean 0.7773, median 0.7151, std 1.0451, max 2.3913, scale 6.22x, CoV 1.34, rel 1.00x, dead 37.5%
-    neurons: 1/1 active, row norm min 4.482 / mean 4.482 / max 4.482
-    bias:    mean -0.1356 (|b| mean 0.1356, max 0.1356)
+    weight:  mean 1.0134, median 0.9399, std 1.3476, max 2.9632, scale 8.11x, CoV 1.33, rel 1.00x, dead 37.5%
+    neurons: 1/1 active, row norm min 5.786 / mean 5.786 / max 5.786
+    bias:    mean -0.1543 (|b| mean 0.1543, max 0.1543)
 
 summary (across 8 buckets) =========================================
   scale (x init):
-    hidden1: avg 2.62x (range 0.89x - 5.27x)
-    hidden2: avg 1.03x (range 0.29x - 2.50x)
-    output : avg 10.44x (range 6.22x - 12.45x)
+    hidden1: avg 2.39x (range 0.80x - 4.80x)
+    hidden2: avg 1.27x (range 0.38x - 3.07x)
+    output : avg 13.90x (range 8.11x - 16.90x)
 
   dead weight fraction:
     hidden1: avg 62.8% (range 25.1% - 88.5%)
@@ -209,23 +209,23 @@ summary (across 8 buckets) =========================================
 
   active neurons (of 16):
     hidden1: avg 6.0 (range 2.0 - 12.0)
-    hidden2: avg 6.6 (range 0.0 - 16.0)
+    hidden2: avg 9.0 (range 2.0 - 16.0)
 
   CoV (std / mean |W|):
-    hidden1: avg 3.14 (range 1.83 - 4.79)
-    hidden2: avg 2.76 (range 1.94 - 4.56)
-    output : avg 1.15 (range 1.06 - 1.34)
+    hidden1: avg 3.09 (range 1.84 - 4.69)
+    hidden2: avg 2.74 (range 1.95 - 4.71)
+    output : avg 1.15 (range 1.05 - 1.33)
 
   rel (x bucket output mean |W|):
-    hidden1: avg 0.02x (range 0.01x - 0.04x)
-    hidden2: avg 0.09x (range 0.03x - 0.20x)
+    hidden1: avg 0.02x (range 0.01x - 0.03x)
+    hidden2: avg 0.09x (range 0.03x - 0.19x)
 
 bucket output similarity (cosine) ==================================
          b1    b2    b3    b4    b5    b6    b7
-  b0  -0.14  0.12  0.56  0.10  0.41 -0.27 -0.09
-  b1         0.20  0.13 -0.26  0.16  0.01 -0.14
-  b2               0.03 -0.44  0.13  0.23 -0.49
-  b3                     0.04  0.43 -0.43 -0.13
-  b4                           0.17 -0.34  0.46
-  b5                                -0.17 -0.31
-  b6                                      -0.29
+  b0  -0.17  0.14  0.56  0.13  0.40 -0.25 -0.07
+  b1         0.20  0.12 -0.24  0.14  0.01 -0.13
+  b2               0.04 -0.41  0.16  0.22 -0.50
+  b3                     0.04  0.46 -0.42 -0.15
+  b4                           0.12 -0.34  0.44
+  b5                                -0.17 -0.34
+  b6                                      -0.26

--- a/nnue/model.safetensors
+++ b/nnue/model.safetensors
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fe37ed2eb0ac76b4949336de8a32b7462b19289c7e0b82decaf73827f564e6bd
+oid sha256:7a2430f7226429368147b1229e78f8d2c8b4138cb74416e5bcfab19eb9f5e933
 size 4342496


### PR DESCRIPTION
New datagen and trained net.

Samples: 1,001,083,382
Games: 32,267,819

20% WDL
74 epochs

<img width="600" height="451" alt="Train Loss and Val Loss" src="https://github.com/user-attachments/assets/7944cfd6-e90b-4021-bb09-2a585fc3f2b6" />
