### PR TITLE
feat: add random opening source and optional imbalance gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2454,6 +2454,7 @@ name = "utils"
 version = "2.0.1"
 dependencies = [
  "cozy-chess",
+ "log",
  "rand 0.10.1",
 ]
 

--- a/README.md
+++ b/README.md
@@ -97,16 +97,28 @@ Generate self-play games to create a dataset:
 
 ```bash
 make generate
-./target/release/generate --book books/your_opening_book.epd
+
+# Openings from an EPD opening book
+./target/release/generate book --path books/your_opening_book.epd
+
+# Openings from startpos + random moves
+./target/release/generate random --plies 8
 ```
+
+**Opening sources (subcommands):**
+
+- `book`: Start games from positions in an opening book.
+  - `--path`: Path to an opening book in EPD format (required).
+- `random`: Start games from startpos plus random moves.
+  - `--plies`: Number of random plies (default: 8). Note: 50% chance an extra ply is added to balance stm.
 
 **Arguments:**
 
-- `--book`: Path to an opening book in EPD format (required).
 - `--depth`: Search depth for each move (default: 8).
 - `--pv-lines`: Number of PV lines to search at each decision point (default: 1).
 - `--threads`: Number of threads (default: number of logical CPUs).
 - `--syzygy-path`: Colon-separated paths to Syzygy tablebase files (optional).
+- `--max-opening-imbalance`: Discard games whose opening eval exceeds this many centipawns in absolute value (optional).
 
 Generated data is saved to `nnue/data/YYYY-MM-DD-HH:MM.csv`.
 

--- a/training/src/bin/generate/args.rs
+++ b/training/src/bin/generate/args.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use clap::{Parser, Subcommand};
 
 #[derive(Parser, Debug)]
 #[command(name = "NNUE Data Generator")]
@@ -6,22 +6,43 @@ use clap::Parser;
 #[command(version = "0.1.0")]
 pub struct Args {
     /// Number of threads. Defaults to the number of logical CPUs.
-    #[arg(long)]
+    #[arg(long, global = true)]
     pub threads: Option<usize>,
 
     /// Search depth for position evaluation.
-    #[arg(long, default_value_t = 8)]
+    #[arg(long, global = true, default_value_t = 8)]
     pub depth: u8,
 
-    /// Path to opening book file (EPD format).
-    #[arg(long)]
-    pub book: String,
-
     /// Number of PV lines to search at each decision point.
-    #[arg(long, default_value_t = 1)]
+    #[arg(long, global = true, default_value_t = 1)]
     pub pv_lines: u8,
 
     /// Colon-separated paths to Syzygy tablebase files.
-    #[arg(long)]
+    #[arg(long, global = true)]
     pub syzygy_path: Option<String>,
+
+    /// Skip openings where the abs eval exceeds this (centipawns).
+    #[arg(long, global = true)]
+    pub max_opening_imbalance: Option<i16>,
+
+    /// Source openings used for self-play games.
+    #[command(subcommand)]
+    pub opening: Opening,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Opening {
+    /// Start from positions in an opening book.
+    Book {
+        /// Path to the opening book (EPD).
+        #[arg(long)]
+        path: String,
+    },
+
+    /// Start from startpos + `plies` random moves.
+    Random {
+        /// Number of random plies.
+        #[arg(long, default_value_t = 8)]
+        plies: usize,
+    },
 }

--- a/training/src/bin/generate/game.rs
+++ b/training/src/bin/generate/game.rs
@@ -4,7 +4,6 @@ use pyrrhic_rs::{TableBases, WdlProbeResult};
 use rand::RngExt;
 use search::{CozyAdapter, Engine, PvLine, SearchResult};
 use std::collections::HashMap;
-use std::str::FromStr;
 use uci::commands::GoParams;
 use utils::{flip_eval_perspective, has_check, has_insufficient_material, has_legal_moves};
 
@@ -18,24 +17,25 @@ pub struct SelfPlayGame {
     position_counts: HashMap<u64, usize>,
     positions: Vec<(String, i16, Move)>, // FEN, eval, best move
     depth: u8,
+    max_opening_imbalance: Option<i16>,
     tablebases: Option<TableBases<CozyAdapter>>,
 }
 
 impl SelfPlayGame {
     pub fn new(
         game_id: usize,
-        opening_fen: &str,
+        board: Board,
         depth: u8,
+        max_opening_imbalance: Option<i16>,
         tablebases: Option<TableBases<CozyAdapter>>,
     ) -> Self {
-        let board = Board::from_str(opening_fen).unwrap();
-
         Self {
             board,
             game_id,
             position_counts: HashMap::new(),
             positions: Vec::new(),
             depth,
+            max_opening_imbalance,
             tablebases,
         }
     }
@@ -58,6 +58,10 @@ impl SelfPlayGame {
             let Some(pv) = result.primary() else {
                 break;
             };
+
+            if self.opening_is_too_imbalanced(pv.score) {
+                return;
+            }
 
             if let Some(mv) = pv.best_move() {
                 self.record_position(pv.score, mv);
@@ -83,6 +87,13 @@ impl SelfPlayGame {
         let white_score = flip_eval_perspective(self.board.side_to_move(), eval);
         self.positions
             .push((format!("{}", self.board), white_score, best_move));
+    }
+
+    fn opening_is_too_imbalanced(&self, score: i16) -> bool {
+        let Some(max) = self.max_opening_imbalance else {
+            return false;
+        };
+        self.positions.is_empty() && score.abs() > max
     }
 
     fn outcome(&self) -> GameOutcome {

--- a/training/src/bin/generate/generator.rs
+++ b/training/src/bin/generate/generator.rs
@@ -1,5 +1,5 @@
-use crate::book::Book;
 use crate::histogram::ScoreHistogram;
+use crate::opening::OpeningSource;
 use crate::samples::Sample;
 use crate::worker::SelfPlayWorker;
 use candle_core::Device;
@@ -20,7 +20,7 @@ const PROGRESS_UPDATE_INTERVAL_MS: u64 = 200;
 pub struct Generator {
     threads: usize,
     pv_lines: u8,
-    opening_book: Arc<Book>,
+    opening_source: Arc<OpeningSource>,
     tablebases: Option<TableBases<CozyAdapter>>,
 }
 
@@ -28,11 +28,9 @@ impl Generator {
     pub fn new(
         threads: usize,
         pv_lines: u8,
-        opening_book_path: String,
+        opening_source: OpeningSource,
         syzygy_path: Option<String>,
     ) -> Result<Self, Box<dyn Error>> {
-        let opening_book = Arc::new(Book::load(&opening_book_path)?);
-
         if !PathBuf::from(MODEL_PATH).exists() {
             return Err(format!(
                 "NNUE model not found at {}. Create an initial model first.",
@@ -55,12 +53,17 @@ impl Generator {
         Ok(Self {
             threads,
             pv_lines,
-            opening_book,
+            opening_source: Arc::new(opening_source),
             tablebases,
         })
     }
 
-    pub fn run(&self, depth: u8, stop_flag: Arc<AtomicBool>) -> Vec<Sample> {
+    pub fn run(
+        &self,
+        depth: u8,
+        max_opening_imbalance: Option<i16>,
+        stop_flag: Arc<AtomicBool>,
+    ) -> Vec<Sample> {
         log::info!(
             "Generating samples (depth={}, multi_pv={}, threads={}) - Press Ctrl+C to stop",
             depth,
@@ -81,7 +84,7 @@ impl Generator {
                 let pv_lines = self.pv_lines;
                 let sample_counter = Arc::clone(&sample_counter);
                 let game_id_counter = Arc::clone(&game_id_counter);
-                let opening_book = Arc::clone(&self.opening_book);
+                let opening_source = Arc::clone(&self.opening_source);
                 let stop_flag = Arc::clone(&stop_flag);
                 let histogram_handle = histogram.clone_handle();
                 let tb = self.tablebases.clone();
@@ -92,9 +95,10 @@ impl Generator {
                         sample_counter,
                         game_id_counter,
                         depth,
+                        max_opening_imbalance,
                         pv_lines,
                         Self::load_nnue,
-                        opening_book,
+                        opening_source,
                         histogram_handle,
                         tb,
                     );

--- a/training/src/bin/generate/main.rs
+++ b/training/src/bin/generate/main.rs
@@ -1,16 +1,17 @@
 mod args;
-mod book;
 mod game;
 mod generator;
 mod histogram;
+mod opening;
 mod samples;
 mod worker;
 
-use args::Args;
+use args::{Args, Opening};
 use chrono::Local;
 use clap::Parser;
 use generator::Generator;
 use log::LevelFilter;
+use opening::OpeningSource;
 use samples::write_samples;
 use simplelog::{Config, SimpleLogger};
 use std::{
@@ -21,6 +22,7 @@ use std::{
         atomic::{AtomicBool, Ordering},
     },
 };
+use utils::Book;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let args = init()?;
@@ -35,8 +37,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     })?;
 
     let threads = args.threads.unwrap_or_else(num_cpus::get);
-    let generator = Generator::new(threads, args.pv_lines, args.book, args.syzygy_path)?;
-    let samples = generator.run(args.depth, stop_flag);
+    let opening = match args.opening {
+        Opening::Book { path } => OpeningSource::Book(Book::load(&path)?),
+        Opening::Random { plies } => OpeningSource::Random { plies },
+    };
+    let generator = Generator::new(threads, args.pv_lines, opening, args.syzygy_path)?;
+    let samples = generator.run(args.depth, args.max_opening_imbalance, stop_flag);
 
     log::info!("Generated {} samples", samples.len());
 

--- a/training/src/bin/generate/opening.rs
+++ b/training/src/bin/generate/opening.rs
@@ -1,0 +1,43 @@
+use cozy_chess::Board;
+use rand::RngExt;
+use utils::{Book, collect_legal_moves, has_legal_moves};
+
+pub enum OpeningSource {
+    /// Openings from a book.
+    Book(Book),
+    /// Openings reached from startpos + `plies` (or `plies + 1`) random moves.
+    Random { plies: usize },
+}
+
+impl OpeningSource {
+    pub fn next_opening(&self) -> Board {
+        match self {
+            Self::Book(book) => book.random_position(),
+            Self::Random { plies } => play_random_from_startpos(*plies),
+        }
+    }
+}
+
+fn play_random_from_startpos(plies: usize) -> Board {
+    let mut rng = rand::rng();
+
+    'attempt: loop {
+        let mut board = Board::default();
+
+        // Randomize parity so both colors get the tempo at the first
+        let plies = plies + rng.random_range(0..=1);
+
+        for _ in 0..plies {
+            let moves = collect_legal_moves(&board);
+            if moves.is_empty() {
+                // The random walk reached checkmate/stalemate, try again
+                continue 'attempt;
+            }
+            board.play_unchecked(moves[rng.random_range(0..moves.len())]);
+        }
+
+        if has_legal_moves(&board) {
+            return board;
+        }
+    }
+}

--- a/training/src/bin/generate/worker.rs
+++ b/training/src/bin/generate/worker.rs
@@ -1,6 +1,6 @@
-use crate::book::Book;
 use crate::game::SelfPlayGame;
 use crate::histogram::HistogramHandle;
+use crate::opening::OpeningSource;
 use crate::samples::Sample;
 use config::EngineConfig;
 use pyrrhic_rs::TableBases;
@@ -19,7 +19,8 @@ pub struct SelfPlayWorker {
     game_id_counter: Arc<AtomicUsize>,
     engine: Engine,
     depth: u8,
-    opening_book: Arc<Book>,
+    max_opening_imbalance: Option<i16>,
+    opening_source: Arc<OpeningSource>,
     histogram: HistogramHandle,
     tablebases: Option<TableBases<CozyAdapter>>,
 }
@@ -32,9 +33,10 @@ impl SelfPlayWorker {
         sample_counter: Arc<AtomicUsize>,
         game_id_counter: Arc<AtomicUsize>,
         depth: u8,
+        max_opening_imbalance: Option<i16>,
         multi_pv: u8,
         create_evaluator: fn() -> nnue::Evaluator,
-        opening_book: Arc<Book>,
+        opening_source: Arc<OpeningSource>,
         histogram: HistogramHandle,
         tablebases: Option<TableBases<CozyAdapter>>,
     ) -> Self {
@@ -55,8 +57,9 @@ impl SelfPlayWorker {
             sample_counter,
             game_id_counter,
             depth,
+            max_opening_imbalance,
             engine,
-            opening_book,
+            opening_source,
             histogram,
             tablebases,
         }
@@ -67,10 +70,15 @@ impl SelfPlayWorker {
 
         while !stop_flag.load(Ordering::Relaxed) {
             let game_id = self.game_id_counter.fetch_add(1, Ordering::Relaxed);
-            let opening_fen = self.opening_book.random_position();
+            let opening = self.opening_source.next_opening();
 
-            let mut game =
-                SelfPlayGame::new(game_id, opening_fen, self.depth, self.tablebases.clone());
+            let mut game = SelfPlayGame::new(
+                game_id,
+                opening,
+                self.depth,
+                self.max_opening_imbalance,
+                self.tablebases.clone(),
+            );
             game.play(&mut self.engine);
 
             let (samples, scores) = game.get_samples();

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -9,6 +9,7 @@ repository = { workspace = true }
 
 [dependencies]
 cozy-chess = { workspace = true }
+log = { workspace = true }
 rand = { workspace = true }
 
 [lints]

--- a/utils/src/book.rs
+++ b/utils/src/book.rs
@@ -1,8 +1,10 @@
+use cozy_chess::Board;
 use rand::RngExt;
 use std::error::Error;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
+use std::str::FromStr;
 
 // EPD has at least 4 fields: board, side, castling, en passant
 const EPD_MIN_FIELDS: usize = 4;
@@ -13,7 +15,7 @@ const DEFAULT_FULLMOVE: u16 = 1;
 /// Opening book loaded from EPD file.
 /// Provides balanced, known opening positions to start self-play from.
 pub struct Book {
-    positions: Vec<String>,
+    positions: Vec<Board>,
 }
 
 impl Book {
@@ -24,7 +26,9 @@ impl Book {
         let mut positions = Vec::new();
         for line in reader.lines() {
             if let Some(fen) = parse_epd_line(&line?) {
-                positions.push(fen);
+                let board = Board::from_str(&fen)
+                    .map_err(|e| format!("invalid FEN in opening book: {fen} ({e})"))?;
+                positions.push(board);
             }
         }
 
@@ -37,10 +41,10 @@ impl Book {
         Ok(Self { positions })
     }
 
-    pub fn random_position(&self) -> &str {
+    pub fn random_position(&self) -> Board {
         let mut rng = rand::rng();
         let index = rng.random_range(0..self.positions.len());
-        &self.positions[index]
+        self.positions[index].clone()
     }
 }
 

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -4,6 +4,7 @@
 mod attacks;
 pub mod bitset;
 pub mod board_metrics;
+mod book;
 mod eval;
 mod material;
 mod math;
@@ -14,6 +15,7 @@ mod ply;
 mod zobrist;
 
 pub use attacks::{get_attackers_to, get_discovered_attacks, get_queen_moves};
+pub use book::Book;
 pub use eval::flip_eval_perspective;
 pub use material::{
     BISHOP_VALUE, KNIGHT_VALUE, MAJOR_PIECES, MINOR_PIECES, NON_PAWN_PIECES, PAWN_PIECES,


### PR DESCRIPTION
## Summary

I know a lot of engines do their datagen with a random walk from the start pos instead of from an opening book. So I implemented a version of that. That also means that some of the openings will be absolute bogus, so i added the imbalance gate as well so later nets dont spend a lot of capacity memorizing unrealistic junk.