### PR TITLE
feat: add soft node limit for datagen and decouple teleport length from depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,10 +115,12 @@ make generate
 **Arguments:**
 
 - `--depth`: Search depth for each move (default: 8).
+- `--nodes`: Soft node limit for each move.
 - `--pv-lines`: Number of PV lines to search at each decision point (default: 1).
 - `--threads`: Number of threads (default: number of logical CPUs).
 - `--syzygy-path`: Colon-separated paths to Syzygy tablebase files (optional).
 - `--max-opening-imbalance`: Discard games whose opening eval exceeds this many centipawns in absolute value (optional).
+- `--max-teleport-plies`: Max plies to teleport along a PV between recorded positions (default: 8).
 
 Generated data is saved to `nnue/data/YYYY-MM-DD-HH:MM.csv`.
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Once added to your GUI, you can configure the engine via the UCI options:
 - **SyzygyPath**: Paths to Syzygy tablebase files (separated by `;` on Windows, `:` on Linux/macOS).
 - **SyzygyProbeDepth**: Minimum depth to probe tablebases (Default: 1).
 
-The engine supports standard time controls (increment, sudden death, moves to go) and analysis modes (fixed depth, infinite).
+The engine supports standard time controls (increment, sudden death, moves to go) and analysis modes (fixed depth, fixed nodes, soft nodes, infinite).
 
 ## Play Against Grail Online
 

--- a/search/src/searcher/search.rs
+++ b/search/src/searcher/search.rs
@@ -96,6 +96,14 @@ impl Searcher {
                 );
             }
 
+            // Soft node limit: finish the current iteration, but don't start
+            // a new one once the budget is spent.
+            if let Some(soft_limit) = params.soft_nodes {
+                if self.shared.total_nodes() + self.nodes >= soft_limit {
+                    break;
+                }
+            }
+
             depth += 1;
         }
 

--- a/training/src/bin/generate/args.rs
+++ b/training/src/bin/generate/args.rs
@@ -13,6 +13,10 @@ pub struct Args {
     #[arg(long, global = true, default_value_t = 8)]
     pub depth: u8,
 
+    /// Soft node limit per position (finishes the ongoing iteration).
+    #[arg(long, global = true, conflicts_with = "depth")]
+    pub nodes: Option<u64>,
+
     /// Number of PV lines to search at each decision point.
     #[arg(long, global = true, default_value_t = 1)]
     pub pv_lines: u8,
@@ -24,6 +28,10 @@ pub struct Args {
     /// Skip openings where the abs eval exceeds this (centipawns).
     #[arg(long, global = true)]
     pub max_opening_imbalance: Option<i16>,
+
+    /// Max plies to teleport along a PV between recorded positions.
+    #[arg(long, global = true, default_value_t = 8, value_parser = clap::value_parser!(u64).range(1..))]
+    pub max_teleport_plies: u64,
 
     /// Source openings used for self-play games.
     #[command(subcommand)]

--- a/training/src/bin/generate/game.rs
+++ b/training/src/bin/generate/game.rs
@@ -1,10 +1,10 @@
+use crate::limit::SearchLimit;
 use crate::samples::{GameOutcome, Sample};
 use cozy_chess::{Board, Color, Move};
 use pyrrhic_rs::{TableBases, WdlProbeResult};
 use rand::RngExt;
 use search::{CozyAdapter, Engine, PvLine, SearchResult};
 use std::collections::HashMap;
-use uci::commands::GoParams;
 use utils::{flip_eval_perspective, has_check, has_insufficient_material, has_legal_moves};
 
 /// A self-play game that generates training samples.
@@ -16,8 +16,9 @@ pub struct SelfPlayGame {
     game_id: usize,
     position_counts: HashMap<u64, usize>,
     positions: Vec<(String, i16, Move)>, // FEN, eval, best move
-    depth: u8,
+    limit: SearchLimit,
     max_opening_imbalance: Option<i16>,
+    max_teleport_plies: usize,
     tablebases: Option<TableBases<CozyAdapter>>,
 }
 
@@ -25,8 +26,9 @@ impl SelfPlayGame {
     pub fn new(
         game_id: usize,
         board: Board,
-        depth: u8,
+        limit: SearchLimit,
         max_opening_imbalance: Option<i16>,
+        max_teleport_plies: usize,
         tablebases: Option<TableBases<CozyAdapter>>,
     ) -> Self {
         Self {
@@ -34,8 +36,9 @@ impl SelfPlayGame {
             game_id,
             position_counts: HashMap::new(),
             positions: Vec::new(),
-            depth,
+            limit,
             max_opening_imbalance,
+            max_teleport_plies,
             tablebases,
         }
     }
@@ -74,13 +77,7 @@ impl SelfPlayGame {
 
     fn search(&self, engine: &mut Engine) -> Option<SearchResult> {
         engine.set_position(self.board.clone(), Some(self.history()));
-
-        let params = GoParams {
-            depth: Some(self.depth),
-            ..Default::default()
-        };
-
-        engine.search(&params, None)
+        engine.search(&self.limit.go_params(), None)
     }
 
     fn record_position(&mut self, eval: i16, best_move: Move) {
@@ -110,17 +107,17 @@ impl SelfPlayGame {
 
     /// Teleport along a PV line by playing moves without searching.
     ///
-    /// Picks a random teleport length from 1 to depth, then plays that many
-    /// moves from the PV. If the PV is shorter than the teleport distance
-    /// (e.g. TB positions where the PV is only 1 move), continues teleporting
-    /// by searching for the best move at each step.
+    /// Picks a random teleport length, then plays that many moves from the
+    /// PV. If the PV is shorter than the teleport distance (e.g. TB positions
+    /// where the PV is only 1 move), continues teleporting by searching for
+    /// the best move at each step.
     fn teleport(&mut self, pv: &PvLine, engine: &mut Engine) {
         if pv.line.is_empty() {
             return;
         }
 
         let mut rng = rand::rng();
-        let teleport_len = rng.random_range(1..=self.depth as usize);
+        let teleport_len = rng.random_range(1..=self.max_teleport_plies);
 
         let mut steps = 0;
 

--- a/training/src/bin/generate/generator.rs
+++ b/training/src/bin/generate/generator.rs
@@ -1,4 +1,5 @@
 use crate::histogram::ScoreHistogram;
+use crate::limit::SearchLimit;
 use crate::opening::OpeningSource;
 use crate::samples::Sample;
 use crate::worker::SelfPlayWorker;
@@ -60,13 +61,14 @@ impl Generator {
 
     pub fn run(
         &self,
-        depth: u8,
+        limit: SearchLimit,
         max_opening_imbalance: Option<i16>,
+        max_teleport_plies: usize,
         stop_flag: Arc<AtomicBool>,
     ) -> Vec<Sample> {
         log::info!(
-            "Generating samples (depth={}, multi_pv={}, threads={}) - Press Ctrl+C to stop",
-            depth,
+            "Generating samples ({}, multi_pv={}, threads={}) - Press Ctrl+C to stop",
+            limit,
             self.pv_lines,
             self.threads,
         );
@@ -94,8 +96,9 @@ impl Generator {
                         tid,
                         sample_counter,
                         game_id_counter,
-                        depth,
+                        limit,
                         max_opening_imbalance,
+                        max_teleport_plies,
                         pv_lines,
                         Self::load_nnue,
                         opening_source,

--- a/training/src/bin/generate/limit.rs
+++ b/training/src/bin/generate/limit.rs
@@ -1,0 +1,35 @@
+use std::fmt;
+use uci::commands::GoParams;
+
+/// Per-move search limit used during self-play.
+#[derive(Clone, Copy, Debug)]
+pub enum SearchLimit {
+    /// Search to a fixed depth.
+    Depth(u8),
+    /// Search until a node budget is spen (finishes the ongoing iteration).
+    SoftNodes(u64),
+}
+
+impl SearchLimit {
+    pub fn go_params(&self) -> GoParams {
+        match self {
+            Self::Depth(depth) => GoParams {
+                depth: Some(*depth),
+                ..Default::default()
+            },
+            Self::SoftNodes(nodes) => GoParams {
+                soft_nodes: Some(*nodes),
+                ..Default::default()
+            },
+        }
+    }
+}
+
+impl fmt::Display for SearchLimit {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Depth(depth) => write!(f, "depth={}", depth),
+            Self::SoftNodes(nodes) => write!(f, "soft_nodes={}", nodes),
+        }
+    }
+}

--- a/training/src/bin/generate/main.rs
+++ b/training/src/bin/generate/main.rs
@@ -2,6 +2,7 @@ mod args;
 mod game;
 mod generator;
 mod histogram;
+mod limit;
 mod opening;
 mod samples;
 mod worker;
@@ -10,6 +11,7 @@ use args::{Args, Opening};
 use chrono::Local;
 use clap::Parser;
 use generator::Generator;
+use limit::SearchLimit;
 use log::LevelFilter;
 use opening::OpeningSource;
 use samples::write_samples;
@@ -41,8 +43,17 @@ fn main() -> Result<(), Box<dyn Error>> {
         Opening::Book { path } => OpeningSource::Book(Book::load(&path)?),
         Opening::Random { plies } => OpeningSource::Random { plies },
     };
+    let limit = match args.nodes {
+        Some(nodes) => SearchLimit::SoftNodes(nodes),
+        None => SearchLimit::Depth(args.depth),
+    };
     let generator = Generator::new(threads, args.pv_lines, opening, args.syzygy_path)?;
-    let samples = generator.run(args.depth, args.max_opening_imbalance, stop_flag);
+    let samples = generator.run(
+        limit,
+        args.max_opening_imbalance,
+        args.max_teleport_plies as usize,
+        stop_flag,
+    );
 
     log::info!("Generated {} samples", samples.len());
 

--- a/training/src/bin/generate/worker.rs
+++ b/training/src/bin/generate/worker.rs
@@ -1,5 +1,6 @@
 use crate::game::SelfPlayGame;
 use crate::histogram::HistogramHandle;
+use crate::limit::SearchLimit;
 use crate::opening::OpeningSource;
 use crate::samples::Sample;
 use config::EngineConfig;
@@ -18,8 +19,9 @@ pub struct SelfPlayWorker {
     sample_counter: Arc<AtomicUsize>,
     game_id_counter: Arc<AtomicUsize>,
     engine: Engine,
-    depth: u8,
+    limit: SearchLimit,
     max_opening_imbalance: Option<i16>,
+    max_teleport_plies: usize,
     opening_source: Arc<OpeningSource>,
     histogram: HistogramHandle,
     tablebases: Option<TableBases<CozyAdapter>>,
@@ -32,8 +34,9 @@ impl SelfPlayWorker {
         tid: usize,
         sample_counter: Arc<AtomicUsize>,
         game_id_counter: Arc<AtomicUsize>,
-        depth: u8,
+        limit: SearchLimit,
         max_opening_imbalance: Option<i16>,
+        max_teleport_plies: usize,
         multi_pv: u8,
         create_evaluator: fn() -> nnue::Evaluator,
         opening_source: Arc<OpeningSource>,
@@ -56,8 +59,9 @@ impl SelfPlayWorker {
             _tid: tid,
             sample_counter,
             game_id_counter,
-            depth,
+            limit,
             max_opening_imbalance,
+            max_teleport_plies,
             engine,
             opening_source,
             histogram,
@@ -75,8 +79,9 @@ impl SelfPlayWorker {
             let mut game = SelfPlayGame::new(
                 game_id,
                 opening,
-                self.depth,
+                self.limit,
                 self.max_opening_imbalance,
+                self.max_teleport_plies,
                 self.tablebases.clone(),
             );
             game.play(&mut self.engine);

--- a/uci/src/commands.rs
+++ b/uci/src/commands.rs
@@ -108,4 +108,7 @@ pub struct GoParams {
     pub move_time: Option<u64>,
     /// Stop after searching this many total nodes.
     pub nodes: Option<u64>,
+    /// Don't start a new iteration after this many total nodes,
+    /// but let the current iteration finish
+    pub soft_nodes: Option<u64>,
 }

--- a/uci/src/decoder.rs
+++ b/uci/src/decoder.rs
@@ -113,6 +113,7 @@ impl Decoder {
             depth: extract_numeric_param(input, "depth").map(|d| d as u8),
             move_time: extract_numeric_param(input, "movetime"),
             nodes: extract_numeric_param(input, "nodes"),
+            soft_nodes: extract_numeric_param(input, "softnodes"),
         })
     }
 }
@@ -186,10 +187,14 @@ mod tests {
         assert_eq!(go("go depth 20").depth, Some(20));
         assert_eq!(go("go movetime 5000").move_time, Some(5000));
 
-        let nodes = go("go nodes 100000");
-        assert_eq!(nodes.nodes, Some(100000));
-        assert!(nodes.depth.is_none());
-        assert!(nodes.move_time.is_none());
+        let hard_nodes = go("go nodes 100000");
+        assert_eq!(hard_nodes.nodes, Some(100000));
+        assert!(hard_nodes.depth.is_none());
+        assert!(hard_nodes.move_time.is_none());
+
+        let soft_nodes = go("go softnodes 30000");
+        assert_eq!(soft_nodes.soft_nodes, Some(30000));
+        assert!(soft_nodes.nodes.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This is something I have wanted to do before the next datagen, but it didn't feel right to put it in the scope of #215, so here it is.

Currently the datagen only accepts a fixed depth for each position it evaluates. The big flaw with this approach is that endgames get evaluated at low depths, which is often where higher depths are needed, such as a K+P endgame.

I've seen instances where Grail gaslights itself into thinking drawn endgames are decisive since it only saw 8 plies ahead in self-play, and once it somehow wins that... it just gets amplified by each new iteration of datagen.

Some node numbers from actual positions:

| Position | Nodes (depth 8) |
| --- | --- |
| Startpos | ~36k |
| Quiet middlegame | ~31k |
| Locked pawn endgame | ~4k |
| K+P vs K | ~1k |

It (obviously) spends more nodes in openings and middlegames, but this is also where (I think) depth matters less since the evals are so uniformly drawish in realistic play, and spending 1k nodes on the endgames that actually need the depth... anyways, probably a lot of potential here :)

## Changes

- **Engine**: new `go softnodes <n>` — don't start a new ID iteration once the budget is spent, but let the current one finish (unlike `nodes`, which yeets mid-search and returns whatever it was holding).
- **Datagen**: new `--nodes` flag (mutually exclusive with `--depth`). Same total compute, but easy positions now search much deeper.
- **Teleporting**: teleport length was coupled to search depth, which was fine when depth was always 8 and very much not fine when a node-limited endgame search returns a depth-25 PV and we warp past the entire game. Now capped by `--max-teleport-plies` (default 8).