### PR TITLE
feat: add anti-reduction in nodes previously PV (ttpv)

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -54,6 +54,7 @@ define_config!(
     (anti_reduction_pv_node: u16, "Anti Reduction PV Node", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
     (anti_reduction_pv_move: u16, "Anti Reduction PV Move", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
     (anti_reduction_tt_pv: u16, "Anti Reduction TT PV", UciOptionType::Spin { min: 0, max: 4096 }, 512, cfg!(feature = "tuning")),
+    (anti_reduction_tt_pv_decay: u16, "Anti Reduction TT PV Decay", UciOptionType::Spin { min: 0, max: 4096 }, 128, cfg!(feature = "tuning")),
     (anti_reduction_tactical: u16, "Anti Reduction Tactical", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
     (anti_reduction_threat: u16, "Anti Reduction Threat", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
     (anti_reduction_check: u16, "Anti Reduction Check", UciOptionType::Spin { min: 0, max: 4096 }, 1500, cfg!(feature = "tuning")),

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -53,6 +53,7 @@ define_config!(
     (anti_reduction_near_root: u16, "Anti Reduction Near Root", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
     (anti_reduction_pv_node: u16, "Anti Reduction PV Node", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
     (anti_reduction_pv_move: u16, "Anti Reduction PV Move", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
+    (anti_reduction_tt_pv: u16, "Anti Reduction TT PV", UciOptionType::Spin { min: 0, max: 4096 }, 512, cfg!(feature = "tuning")),
     (anti_reduction_tactical: u16, "Anti Reduction Tactical", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
     (anti_reduction_threat: u16, "Anti Reduction Threat", UciOptionType::Spin { min: 0, max: 4096 }, 1024, cfg!(feature = "tuning")),
     (anti_reduction_check: u16, "Anti Reduction Check", UciOptionType::Spin { min: 0, max: 4096 }, 1500, cfg!(feature = "tuning")),

--- a/search/src/searcher/pruning.rs
+++ b/search/src/searcher/pruning.rs
@@ -148,6 +148,7 @@ impl Searcher {
         try_null_move: bool,
         corrected_eval: Option<i16>,
         static_eval: i16,
+        tt_pv: bool,
     ) -> Option<i16> {
         if !try_null_move
             || in_check
@@ -215,6 +216,7 @@ impl Searcher {
             bounds.alpha,
             bounds.beta,
             None,
+            tt_pv,
         );
 
         Some(null_value)
@@ -233,6 +235,7 @@ impl Searcher {
         bounds: Bounds,
         ply: u8,
         is_improving: bool,
+        tt_pv: bool,
     ) -> Option<i16> {
         if depth == 0 || depth > self.config.rfp_max_depth.value || in_check || node.is_pv() {
             return None;
@@ -254,6 +257,7 @@ impl Searcher {
                 bounds.alpha,
                 bounds.beta,
                 None,
+                tt_pv,
             );
             return Some(bounds.beta);
         }

--- a/search/src/searcher/quiescence.rs
+++ b/search/src/searcher/quiescence.rs
@@ -55,6 +55,7 @@ impl Searcher {
         let original_bounds = bounds;
 
         let tt_info = self.shared.tt().probe(hash, ply);
+        let tt_pv = node.is_pv() || tt_info.is_some_and(|t| t.pv);
         if let Some(tt) = tt_info {
             if !node.is_pv() {
                 match tt.bound {
@@ -96,6 +97,7 @@ impl Searcher {
                     original_bounds.alpha,
                     original_bounds.beta,
                     None,
+                    tt_pv,
                 );
                 return stand_pat;
             }
@@ -125,6 +127,7 @@ impl Searcher {
                         original_bounds.alpha,
                         original_bounds.beta,
                         None,
+                        tt_pv,
                     );
                     return stand_pat;
                 }
@@ -216,6 +219,7 @@ impl Searcher {
             original_bounds.alpha,
             original_bounds.beta,
             None,
+            tt_pv,
         );
         best_eval
     }

--- a/search/src/searcher/reduction.rs
+++ b/search/src/searcher/reduction.rs
@@ -1,7 +1,5 @@
 use utils::{FracPly, Node, creates_threat, evades_threat};
 
-use crate::utils::near_root;
-
 use super::Searcher;
 
 impl Searcher {
@@ -23,6 +21,7 @@ impl Searcher {
         hist: i16,
         cont_hist: i16,
         tt_move_is_capture: bool,
+        tt_pv: bool,
     ) -> u8 {
         let mut reduction = self.lmr.get(depth, move_index);
 
@@ -52,14 +51,17 @@ impl Searcher {
 
         // Reduce less
         if reduction > FracPly(0) {
-            if is_pv_move {
-                reduction -= FracPly(self.config.anti_reduction_pv_move.value);
-            }
             if near_root(ply, depth) {
                 reduction -= FracPly(self.config.anti_reduction_near_root.value);
             }
+            if is_pv_move {
+                reduction -= FracPly(self.config.anti_reduction_pv_move.value);
+            }
             if parent.is_pv() {
                 reduction -= FracPly(self.config.anti_reduction_pv_node.value);
+            } else if tt_pv {
+                // Node that has been a PV earlier
+                reduction -= FracPly(self.config.anti_reduction_tt_pv.value);
             }
             if parent.in_check() || child.in_check() {
                 reduction -= FracPly(self.config.anti_reduction_check.value);
@@ -84,4 +86,9 @@ fn history_reduction(reduction: &mut FracPly, score: i16, divisor: i32) {
     } else {
         *reduction += delta
     }
+}
+
+pub fn near_root(ply: u8, depth: u8) -> bool {
+    let total_depth = depth + ply;
+    ply <= total_depth >> 3 // 12.5% of the total depth
 }

--- a/search/src/searcher/reduction.rs
+++ b/search/src/searcher/reduction.rs
@@ -22,6 +22,7 @@ impl Searcher {
         cont_hist: i16,
         tt_move_is_capture: bool,
         tt_pv: bool,
+        tt_age: u8,
     ) -> u8 {
         let mut reduction = self.lmr.get(depth, move_index);
 
@@ -60,8 +61,10 @@ impl Searcher {
             if parent.is_pv() {
                 reduction -= FracPly(self.config.anti_reduction_pv_node.value);
             } else if tt_pv {
-                // Node that has been a PV earlier
-                reduction -= FracPly(self.config.anti_reduction_tt_pv.value);
+                // Node that has been a PV earlier (tapers off as the TT entry goes stale)
+                let base = self.config.anti_reduction_tt_pv.value as u32;
+                let falloff = tt_age as u32 * self.config.anti_reduction_tt_pv_decay.value as u32;
+                reduction -= FracPly(base.saturating_sub(falloff) as u16);
             }
             if parent.in_check() || child.in_check() {
                 reduction -= FracPly(self.config.anti_reduction_check.value);

--- a/search/src/searcher/search.rs
+++ b/search/src/searcher/search.rs
@@ -315,6 +315,7 @@ impl Searcher {
         let in_check = node.in_check();
         let tt_move = tt_info.and_then(|t| t.best_move);
         let tt_move_is_capture = tt_move.is_some_and(|m| node.is_capture(m));
+        let tt_pv = is_pv_node || tt_info.is_some_and(|t| t.pv);
 
         let static_eval = tt_info
             .and_then(|t| t.static_eval)
@@ -359,6 +360,7 @@ impl Searcher {
                 null_move_allowed,
                 Some(corrected_eval),
                 static_eval,
+                tt_pv,
             ) {
                 return score;
             }
@@ -375,6 +377,7 @@ impl Searcher {
             bounds,
             ply,
             is_improving,
+            tt_pv,
         ) {
             return score;
         }
@@ -467,6 +470,7 @@ impl Searcher {
                 corrected_eval,
                 singular_result.extension,
                 &prev_moves,
+                tt_pv,
             ) {
                 if self.shared.is_stopped() {
                     break;
@@ -530,6 +534,7 @@ impl Searcher {
                 original_bounds.alpha,
                 bounds.beta,
                 best_move,
+                tt_pv,
             );
         }
 
@@ -565,6 +570,7 @@ impl Searcher {
         static_eval: i16,
         extra_extension: i8,
         prev_moves: &PrevMoves,
+        tt_pv: bool,
     ) -> Option<(i16, bool, u8)> {
         let moved_color = node.board().side_to_move();
         let moved_piece = node.piece_on(m.from).unwrap();
@@ -633,6 +639,7 @@ impl Searcher {
             hist,
             cont_hist,
             tt_move_is_capture,
+            tt_pv,
         );
 
         let extension = self.get_extension(node, &m, moved_piece, is_cap);

--- a/search/src/searcher/search.rs
+++ b/search/src/searcher/search.rs
@@ -316,6 +316,7 @@ impl Searcher {
         let tt_move = tt_info.and_then(|t| t.best_move);
         let tt_move_is_capture = tt_move.is_some_and(|m| node.is_capture(m));
         let tt_pv = is_pv_node || tt_info.is_some_and(|t| t.pv);
+        let tt_age = tt_info.map_or(0, |t| t.age);
 
         let static_eval = tt_info
             .and_then(|t| t.static_eval)
@@ -471,6 +472,7 @@ impl Searcher {
                 singular_result.extension,
                 &prev_moves,
                 tt_pv,
+                tt_age,
             ) {
                 if self.shared.is_stopped() {
                     break;
@@ -571,6 +573,7 @@ impl Searcher {
         extra_extension: i8,
         prev_moves: &PrevMoves,
         tt_pv: bool,
+        tt_age: u8,
     ) -> Option<(i16, bool, u8)> {
         let moved_color = node.board().side_to_move();
         let moved_piece = node.piece_on(m.from).unwrap();
@@ -640,6 +643,7 @@ impl Searcher {
             cont_hist,
             tt_move_is_capture,
             tt_pv,
+            tt_age,
         );
 
         let extension = self.get_extension(node, &m, moved_piece, is_cap);

--- a/search/src/transposition.rs
+++ b/search/src/transposition.rs
@@ -33,6 +33,8 @@ pub struct ProbeResult {
     pub static_eval: Option<i16>,
     /// Depth of the search that produced this entry.
     pub depth: u8,
+    /// Whether this position has been a PV node before.
+    pub pv: bool,
 }
 
 /// A single TT entry (16 bytes, fits 4 per cache line).
@@ -53,6 +55,8 @@ pub struct TTEntry {
     pub best_move_packed: u16,
     /// Generation for age-based replacement.
     pub generation: u8,
+    /// Whether this position has been a PV node before.
+    pub pv: bool,
 }
 
 const CLUSTER_SIZE: usize = 4;
@@ -180,6 +184,7 @@ impl TranspositionTable {
             best_move: unpack_move(entry.best_move_packed),
             static_eval,
             depth: entry.depth,
+            pv: entry.pv,
         })
     }
 
@@ -195,6 +200,7 @@ impl TranspositionTable {
         alpha: i16,
         beta: i16,
         best_move: Option<Move>,
+        pv: bool,
     ) {
         let best_move_packed = pack_move(best_move);
         let key32 = hash as u32;
@@ -234,6 +240,7 @@ impl TranspositionTable {
             depth,
             best_move_packed,
             generation: current_gen,
+            pv,
         };
 
         // Exact bounds are more useful than upper bounds at the same depth.
@@ -258,6 +265,9 @@ impl TranspositionTable {
                         // and in such cases we should just keep the old one.
                         new_entry.best_move_packed = e.best_move_packed;
                     }
+
+                    new_entry.pv |= e.pv; // (is/was PV)
+
                     *e = new_entry;
                 }
                 return;

--- a/search/src/transposition.rs
+++ b/search/src/transposition.rs
@@ -35,6 +35,8 @@ pub struct ProbeResult {
     pub depth: u8,
     /// Whether this position has been a PV node before.
     pub pv: bool,
+    /// How many searches ago this entry was last written
+    pub age: u8,
 }
 
 /// A single TT entry (16 bytes, fits 4 per cache line).
@@ -185,6 +187,7 @@ impl TranspositionTable {
             static_eval,
             depth: entry.depth,
             pv: entry.pv,
+            age: self.generation.wrapping_sub(entry.generation),
         })
     }
 

--- a/search/src/utils/mod.rs
+++ b/search/src/utils/mod.rs
@@ -4,8 +4,3 @@ pub mod see;
 
 pub use bounds::Bounds;
 pub use score::{convert_centipawn_score, convert_mate_score};
-
-pub fn near_root(ply: u8, depth: u8) -> bool {
-    let total_depth = depth + ply;
-    ply <= total_depth >> 3 // 12.5% of the total depth
-}


### PR DESCRIPTION
## Summary

I tried adding the "reduce positions less if it has been a pv node in the past/now". But it regressed. Ended up down a rabbit hole but found some interesting results with the "near root" anti-reduction:

```
--------------------------------------------------
Rank Name                             Elo        +/-       nElo        +/-      Games      Score       Draw           Ptnml(0-2)
   1 near-root                      12.21      10.25      21.12      17.70       1480      51.8%      46.5% [12, 165, 344, 197, 22]
   2 ttpv                            0.70      17.61       1.22      30.64        494      50.1%      48.6%  [6, 57, 120, 58, 6]
   3 none                          -18.30      17.79     -31.62      30.64        494      47.4%      44.1%  [7, 73, 109, 55, 3]
   4 both                          -19.09      17.80     -33.02      30.70        492      47.3%      46.7%  [9, 67, 115, 52, 3]
--------------------------------------------------
```

Will do some follow-up experimentation.

