### PR TITLE
feat: added bench command (uci)

### DIFF
--- a/core/src/bench.rs
+++ b/core/src/bench.rs
@@ -1,0 +1,135 @@
+use std::str::FromStr;
+use std::sync::mpsc::channel;
+
+use cozy_chess::Board;
+use search::Engine;
+use uci::UciOutput;
+use uci::commands::{GoParams, Info, Score};
+
+const DEPTH: u8 = 14;
+
+pub fn run_benchmark(engine: &mut Engine) {
+    let params = GoParams {
+        depth: Some(DEPTH),
+        ..GoParams::default()
+    };
+
+    let (tx, rx) = channel();
+    let mut stats = Stats::default();
+
+    for (i, fen) in POSITIONS.iter().enumerate() {
+        let board = Board::from_str(fen).expect("valid FEN");
+
+        engine.new_game();
+        engine.set_position(board, None);
+        let _ = engine.search(&params, Some(&tx));
+
+        let Some(UciOutput::Info(info)) = rx.try_iter().last() else {
+            panic!("No info from search ({fen})");
+        };
+
+        stats.record(i, fen, &info);
+    }
+
+    stats.print_summary();
+}
+
+#[derive(Default)]
+struct Stats {
+    total_nodes: u64,
+    total_time: u64,
+    total_branch_factor: f64,
+}
+
+impl Stats {
+    fn record(&mut self, index: usize, fen: &str, info: &Info) {
+        let branch_factor = (info.nodes as f64).powf(1.0 / info.depth as f64);
+
+        self.total_nodes += info.nodes;
+        self.total_time += info.time as u64;
+        self.total_branch_factor += branch_factor;
+
+        let best_move = info.pv.first().map(String::as_str).unwrap_or("-");
+
+        println!(
+            "[{:>2}/{}]  bestmove {:<5}  depth {:>2}  score {:>9}  nodes {:>9}  time {:>6} ms  bf {:>5.2}  {}",
+            index + 1,
+            POSITIONS.len(),
+            best_move,
+            info.depth,
+            format_score(&info.score),
+            info.nodes,
+            info.time,
+            branch_factor,
+            fen,
+        );
+    }
+
+    fn print_summary(&self) {
+        let nodes = self.total_nodes;
+        let ms = self.total_time;
+        let nps = nodes * 1000 / ms;
+        let branch_factor = self.total_branch_factor / POSITIONS.len() as f64;
+
+        println!();
+        println!("Total time          : {ms} ms");
+        println!("Total nodes         : {nodes}");
+        println!("Avg NPS             : {nps}");
+        println!("Avg branching factor: {branch_factor:.2}");
+    }
+}
+
+fn format_score(score: &Score) -> String {
+    match score {
+        Score::Centipawns(cp) => format!("{cp} cp"),
+        Score::Mate(n) => format!("{n} M"),
+    }
+}
+
+// Shamelessly yoinked from Stockfish (with modifications)
+const POSITIONS: &[&str] = &[
+    "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+    "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 10",
+    "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 11",
+    "4rrk1/pp1n3p/3q2pQ/2p1pb2/2PP4/2P3N1/P2B2PP/4RRK1 b - - 7 19",
+    "rq3rk1/ppp2ppp/1bnpN3/3N2B1/4P3/7P/PPPQ1PP1/2KR3R b - - 0 14",
+    "r1bq1r1k/1pp1n1pp/1p1p4/4p2Q/4PpP1/1BNP4/PPP2P1P/3R1RK1 b - g3 0 14",
+    "r3r1k1/2p2ppp/p1p1bn2/8/1q2P3/2NPQN2/PPP3PP/R4RK1 b - - 2 15",
+    "r1bbk1nr/pp3p1p/2n5/1N4p1/2Np1B2/8/PPP2PPP/2KR1B1R w kq - 0 13",
+    "r1bq1rk1/ppp1nppp/4n3/3p3Q/3P4/1BP1B3/PP1N2PP/R4RK1 w - - 1 16",
+    "4r1k1/r1q2ppp/ppp2n2/4P3/5Rb1/1N1BQ3/PPP3PP/R5K1 w - - 1 17",
+    "2rqkb1r/ppp2p2/2npb1p1/1N1Nn2p/2P1PP2/8/PP2B1PP/R1BQK2R b KQ - 0 11",
+    "r1bq1r1k/b1p1npp1/p2p3p/1p6/3PP3/1B2NN2/PP3PPP/R2Q1RK1 w - - 1 16",
+    "3r1rk1/p5pp/bpp1pp2/8/q1PP1P2/b3P3/P2NQRPP/1R2B1K1 b - - 6 22",
+    "r1q2rk1/2p1bppp/2Pp4/p6b/Q1PNp3/4B3/PP1R1PPP/2K4R w - - 2 18",
+    "4k2r/1pb2ppp/1p2p3/1R1p4/3P4/2r1PN2/P4PPP/1R4K1 b - - 3 22",
+    "3q2k1/pb3p1p/4pbp1/2r5/PpN2N2/1P2P2P/5PP1/Q2R2K1 b - - 4 26",
+    "6k1/6p1/6Pp/ppp5/3pn2P/1P3K2/1PP2P2/3N4 b - - 0 1",
+    "3b4/5kp1/1p1p1p1p/pP1PpP1P/P1P1P3/3KN3/8/8 w - - 0 1",
+    "2K5/p7/7P/5pR1/8/5k2/r7/8 w - - 4 3",
+    "8/6pk/1p6/8/PP3p1p/5P2/4KP1q/3Q4 w - - 0 1",
+    "7k/3p2pp/4q3/8/4Q3/5Kp1/P6b/8 w - - 0 1",
+    "8/2p5/8/2kPKp1p/2p4P/2P5/3P4/8 w - - 0 1",
+    "8/1p3pp1/7p/5P1P/2k3P1/8/2K2P2/8 w - - 0 1",
+    "8/pp2r1k1/2p1p3/3pP2p/1P1P1P1P/P5KR/8/8 w - - 0 1",
+    "8/3p4/p1bk3p/Pp6/1Kp1PpPp/2P2P1P/2P5/5B2 b - - 0 1",
+    "5k2/7R/4P2p/5K2/p1r2P1p/8/8/8 b - - 0 1",
+    "6k1/6p1/P6p/r1N5/5p2/7P/1b3PP1/4R1K1 w - - 0 1",
+    "1r3k2/4q3/2Pp3b/3Bp3/2Q2p2/1p1P2P1/1P2KP2/3N4 w - - 0 1",
+    "6k1/4pp1p/3p2p1/P1pPb3/R7/1r2P1PP/3B1P2/6K1 w - - 0 1",
+    "8/3p3B/5p2/5P2/p7/PP5b/k7/6K1 w - - 0 1",
+    "5rk1/q6p/2p3bR/1pPp1rP1/1P1Pp3/P3B1Q1/1K3P2/R7 w - - 93 90",
+    "4rrk1/1p1nq3/p7/2p1P1pp/3P2bp/3Q1Bn1/PPPB4/1K2R1NR w - - 40 21",
+    "r3k2r/3nnpbp/q2pp1p1/p7/Pp1PPPP1/4BNN1/1P5P/R2Q1RK1 w kq - 0 16",
+    "3Qb1k1/1r2ppb1/pN1n2q1/Pp1Pp1Pr/4P2p/4BP2/4B1R1/1R5K b - - 11 40",
+    "4k3/3q1r2/1N2r1b1/3ppN2/2nPP3/1B1R2n1/2R1Q3/3K4 w - - 5 1",
+    "8/8/8/8/5kp1/P7/8/1K1N4 w - - 0 1",
+    "8/8/8/5N2/8/p7/8/2NK3k w - - 0 1",
+    "8/3k4/8/8/8/4B3/4KB2/2B5 w - - 0 1",
+    "8/8/1P6/5pr1/8/4R3/7k/2K5 w - - 0 1",
+    "8/2p4P/8/kr6/6R1/8/8/1K6 w - - 0 1",
+    "8/8/3P3k/8/1p6/8/1P6/1K3n2 b - - 0 1",
+    "8/R7/2q5/8/6k1/8/1P5p/K6R w - - 0 124",
+    "6k1/3b3r/1p1p4/p1n2p2/1PPNpP1q/P3Q1p1/1R1RB1P1/5K2 b - - 0 1",
+    "r2r1n2/pp2bk2/2p1p2p/3q4/3PN1QP/2P3R1/P4PP1/5RK1 w - - 0 1",
+];

--- a/core/src/grail.rs
+++ b/core/src/grail.rs
@@ -53,15 +53,22 @@ impl Grail {
     }
 
     /// Runs the UCI protocol loop until quit.
-    pub fn run(mut self) -> Result<(), Box<dyn std::error::Error>> {
+    /// If an initial line is provided, it is executed and the program exits.
+    pub fn run(mut self, initial: Option<String>) -> Result<(), Box<dyn std::error::Error>> {
         let decoder = Decoder::new();
-        let stdin = std::io::stdin();
 
-        for line in stdin.lock().lines() {
-            let line = line?;
-            let input = decoder.decode(line.trim());
-            if !self.handle(input) {
-                break;
+        match initial {
+            Some(line) => {
+                self.handle(decoder.decode(line.trim()));
+            }
+            None => {
+                let stdin = std::io::stdin();
+                for line in stdin.lock().lines() {
+                    let line = line?;
+                    if !self.handle(decoder.decode(line.trim())) {
+                        break;
+                    }
+                }
             }
         }
 
@@ -118,6 +125,9 @@ impl Grail {
             }
             UciInput::Display => {
                 let _ = self.cmd_tx.send(EngineCommand::Display);
+            }
+            UciInput::Bench => {
+                let _ = self.cmd_tx.send(EngineCommand::Bench);
             }
             UciInput::Quit => return false,
             UciInput::Unknown(_) => {} // Ignore unknown commands per UCI spec

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -1,3 +1,4 @@
+mod bench;
 mod display;
 mod engine;
 mod grail;
@@ -10,5 +11,13 @@ use std::error::Error;
 use grail::Grail;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    Grail::new().run()
+    Grail::new().run(parse_args_to_uci())
+}
+
+/// Parse CLI arguments as a UCI command.
+/// Allows a one-time run of a single UCI command, like "grail go depth 15" etc then exit.
+/// I see Stockfish does it this way, probably to run the benchmark easier for PGO.
+fn parse_args_to_uci() -> Option<String> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    (!args.is_empty()).then(|| args.join(" "))
 }

--- a/core/src/worker.rs
+++ b/core/src/worker.rs
@@ -6,6 +6,7 @@ use cozy_chess::Board;
 use search::Engine;
 use uci::{NULL_MOVE, UciOutput, move_to_uci};
 
+use crate::bench::run_benchmark;
 use crate::display::display_position;
 use crate::search_metadata::SearchResultMeta;
 
@@ -24,6 +25,8 @@ pub enum EngineCommand {
     Go(uci::commands::GoParams),
     /// Display current position.
     Display,
+    /// Run the engine benchmark.
+    Bench,
     /// Shut down the worker thread.
     Quit,
 }
@@ -86,6 +89,7 @@ impl EngineWorker {
                 EngineCommand::Display => {
                     display_position(self.engine.board(), self.last_search.as_ref())
                 }
+                EngineCommand::Bench => run_benchmark(&mut self.engine),
                 EngineCommand::Quit => break,
             }
         }

--- a/uci/src/commands.rs
+++ b/uci/src/commands.rs
@@ -25,6 +25,7 @@ pub enum UciInput {
 
     /// Non-standard commands
     Display,
+    Bench,
 }
 
 /// Commands sent to the UCI GUI.

--- a/uci/src/decoder.rs
+++ b/uci/src/decoder.rs
@@ -33,6 +33,7 @@ impl Decoder {
 
             // Non-standard commands
             "d" => UciInput::Display,
+            "bench" => UciInput::Bench,
 
             _ => UciInput::Unknown(input.to_string()),
         }


### PR DESCRIPTION
## Summary

Adding a bench uci command for benchmarking and profiling with flamegraph. Also (maybe) for future PGO builds.
To make that easier to run in commands such as flamegraph I allow a single-run uci command as arguments to the program so that `./grail go depth 15` or `./grail bench` runs that single uci command and exits.

Also shamelessly yoinked the positions from Stockfish's bench command (and modified it a bit).