### PR TITLE
perf: pgo builds (makefile target + release ci)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          PGO_DIR="$PWD/target/pgo-data"
+          PGO_DIR="target/pgo-data"
           rm -rf "$PGO_DIR"
           mkdir -p "$PGO_DIR"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          PGO_DIR="target/pgo-data"
+          ROOT="$(pwd -W 2>/dev/null || pwd)"
+          PGO_DIR="$ROOT/target/pgo-data"
           rm -rf "$PGO_DIR"
           mkdir -p "$PGO_DIR"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build binaries
 
+# note: pgo_cpu is used to build the instrumented binary for pgo builds.
+# - no guarantee that the CI runner has the same CPU as the target CPU.
+
 on:
   workflow_dispatch: # Allow manual runs from Actions tab
   push:
@@ -16,11 +19,13 @@ jobs:
             name: linux
             rust_target: x86_64-unknown-linux-gnu
             cpu: x86-64-v4
+            pgo_cpu: x86-64-v3
             binary_name: grail-x86-64-v4
           - os: ubuntu-latest
             name: linux
             rust_target: x86_64-unknown-linux-gnu
             cpu: x86-64-v3
+            pgo_cpu: x86-64-v3
             binary_name: grail-x86-64-v3
 
           # Windows builds
@@ -28,11 +33,13 @@ jobs:
             name: windows
             rust_target: x86_64-pc-windows-msvc
             cpu: x86-64-v4
+            pgo_cpu: x86-64-v3
             binary_name: grail-x86-64-v4
           - os: windows-latest
             name: windows
             rust_target: x86_64-pc-windows-msvc
             cpu: x86-64-v3
+            pgo_cpu: x86-64-v3
             binary_name: grail-x86-64-v3
 
           # macOS Apple Silicon
@@ -40,6 +47,7 @@ jobs:
             name: macos
             rust_target: aarch64-apple-darwin
             cpu: native
+            pgo_cpu: native
             binary_name: grail-arm64
 
     runs-on: ${{ matrix.os }}
@@ -49,11 +57,29 @@ jobs:
           lfs: true
       - run: rustup default nightly
       - run: rustup target add ${{ matrix.rust_target }}
-      - run: cargo build --release --target ${{ matrix.rust_target }}
-        env:
-          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C target-cpu=${{ matrix.cpu }}"
-          CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_RUSTFLAGS: "-C target-cpu=${{ matrix.cpu }}"
-          CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS: "-C target-cpu=${{ matrix.cpu }}"
+      - run: rustup component add llvm-tools-preview
+
+      - name: PGO build
+        shell: bash
+        run: |
+          set -euo pipefail
+          PGO_DIR="$PWD/target/pgo-data"
+          rm -rf "$PGO_DIR"
+          mkdir -p "$PGO_DIR"
+
+          PROFDATA="$(dirname "$(rustc --print target-libdir)")/bin/llvm-profdata"
+          [ -x "$PROFDATA.exe" ] && PROFDATA="$PROFDATA.exe"
+
+          RUSTFLAGS="-C target-cpu=${{ matrix.pgo_cpu }} -C profile-generate=$PGO_DIR" \
+            cargo build --release --target ${{ matrix.rust_target }} -p grail --bin grail
+
+          LLVM_PROFILE_FILE="$PGO_DIR/grail-%p-%m.profraw" \
+            "target/${{ matrix.rust_target }}/release/grail" bench
+
+          "$PROFDATA" merge -o "$PGO_DIR/merged.profdata" "$PGO_DIR"
+
+          RUSTFLAGS="-C target-cpu=${{ matrix.cpu }} -C profile-use=$PGO_DIR/merged.profdata -C llvm-args=-pgo-warn-missing-function=false" \
+            cargo build --release --target ${{ matrix.rust_target }} -p grail --bin grail
 
       # Rename binary to include CPU info
       - name: Rename binary (Unix)

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,25 @@ SHELL = /bin/bash
 
 .ONESHELL:
 
-.PHONY: grail tunable generate train clean nnue-analysis profile
+.PHONY: grail tunable generate train clean nnue-analysis profile pgo
 
 # Default to native optimization for local development.
 RUSTFLAGS = -C target-cpu=native
 
 grail:
 	RUSTFLAGS="$(RUSTFLAGS)" cargo build --release --bin grail
+
+# PGO build (used for releases).
+# Needs llvm-profdata from the llvm-tools-preview component (rustup component add llvm-tools-preview).
+pgo:
+	PGO_DIR="$(CURDIR)/target/pgo-data"
+	rm -rf "$$PGO_DIR"
+	mkdir -p "$$PGO_DIR"
+	PROFDATA="$$(dirname "$$(rustc --print target-libdir)")/bin/llvm-profdata"
+	RUSTFLAGS="$(RUSTFLAGS) -C profile-generate=$$PGO_DIR" cargo build --release --bin grail
+	LLVM_PROFILE_FILE="$$PGO_DIR/grail-%p-%m.profraw" ./target/release/grail bench
+	"$$PROFDATA" merge -o "$$PGO_DIR/merged.profdata" "$$PGO_DIR"
+	RUSTFLAGS="$(RUSTFLAGS) -C profile-use=$$PGO_DIR/merged.profdata -C llvm-args=-pgo-warn-missing-function=false" cargo build --release --bin grail
 
 tunable:
 	RUSTFLAGS="$(RUSTFLAGS)" cargo build --release --bin grail --features tuning

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The project includes a `Makefile` for convenience:
 - **`make generate`**: Builds the data generation tool for NNUE training.
 - **`make train`**: Builds the NNUE trainer (auto-detects CUDA/Metal).
 - **`make nnue-analysis`**: Dumps a human-readable weight analysis of the current NNUE to `nnue/model.analysis.txt`.
+- **`make pgo`**: Builds a PGO release.
 - **`make profile`**: Records the built-in benchmark with [`samply`](https://github.com/mstange/samply) (install required).
 - **`make clean`**: Cleans the build directory.
 


### PR DESCRIPTION
## Summary

Saw a roughly 10% NPS uplift on my Ryzen 9 9950X Linux setup with PGO, which translated to roughly +14 Elo in STC. After some back and forth it was (relatively...) trivial to add this to the release build CI action too, and it [seems to work](https://github.com/jorgenhanssen/grail/actions/runs/27639825568)!

Have tested the linux and windows versions, but have not yet tested the Mac one, although I assume it works.

Updated the `build.yml` for PGO in the CI and added a `make pgo` target in the Makefile.