### PR TITLE
feat: relabel datagen outcomes from tablebase WDL

### DIFF
--- a/training/src/bin/generate/game.rs
+++ b/training/src/bin/generate/game.rs
@@ -1,9 +1,8 @@
 use crate::limit::SearchLimit;
-use crate::samples::{GameOutcome, Sample};
-use cozy_chess::{Board, Color, Move};
-use pyrrhic_rs::{TableBases, WdlProbeResult};
+use crate::samples::GameOutcome;
+use cozy_chess::{Board, Move};
 use rand::{RngExt, rng};
-use search::{CozyAdapter, Engine, SearchResult};
+use search::{Engine, SearchResult};
 use std::collections::HashMap;
 use utils::{flip_eval_perspective, has_check, has_insufficient_material, has_legal_moves};
 
@@ -16,35 +15,33 @@ pub struct GameConfig {
     pub dense_sampling: bool,
 }
 
-/// A self-play game that generates training samples.
+/// A recorded position/sample (outcomes are labelled in the refinery).
+pub struct Position {
+    pub fen: String,
+    pub score: i16,
+    pub best_move: Move,
+}
+
+/// A self-play game that records positions for training.
 ///
 /// Uses MultiPV search at decision points and teleports along chosen PV lines
 /// to produce varied games from the same openings.
 pub struct SelfPlayGame {
     board: Board,
-    game_id: usize,
     position_counts: HashMap<u64, usize>,
-    positions: Vec<(String, i16, Move)>, // FEN, eval, best move
+    positions: Vec<Position>,
     plies_played: usize,
     config: GameConfig,
-    tablebases: Option<TableBases<CozyAdapter>>,
 }
 
 impl SelfPlayGame {
-    pub fn new(
-        game_id: usize,
-        board: Board,
-        config: GameConfig,
-        tablebases: Option<TableBases<CozyAdapter>>,
-    ) -> Self {
+    pub fn new(board: Board, config: GameConfig) -> Self {
         Self {
             board,
-            game_id,
             position_counts: HashMap::new(),
             positions: Vec::new(),
             plies_played: 0,
             config,
-            tablebases,
         }
     }
 
@@ -109,8 +106,11 @@ impl SelfPlayGame {
 
     fn record_position(&mut self, eval: i16, best_move: Move) {
         let white_score = flip_eval_perspective(self.board.side_to_move(), eval);
-        self.positions
-            .push((format!("{}", self.board), white_score, best_move));
+        self.positions.push(Position {
+            fen: format!("{}", self.board),
+            score: white_score,
+            best_move,
+        });
     }
 
     fn opening_is_too_imbalanced(&self, score: i16) -> bool {
@@ -120,16 +120,24 @@ impl SelfPlayGame {
         self.positions.is_empty() && score.abs() > max
     }
 
-    fn outcome(&self) -> GameOutcome {
-        if !has_legal_moves(&self.board) && has_check(&self.board) {
-            return if self.board.side_to_move() == Color::White {
-                GameOutcome::Black
+    /// The game outcome. Returns None for speculative draws (50-move rule / repetition)
+    pub fn outcome(&self) -> Option<GameOutcome> {
+        if !has_legal_moves(&self.board) {
+            return Some(if has_check(&self.board) {
+                GameOutcome::win(!self.board.side_to_move())
             } else {
-                GameOutcome::White
-            };
+                GameOutcome::Draw
+            });
         }
 
-        GameOutcome::Draw
+        if has_insufficient_material(&self.board) {
+            return Some(GameOutcome::Draw);
+        }
+
+        // During some testing, I found that a winning game can still end in a draw in datagen.
+        // Looked like it could shuffle won endgames into draws somehow.
+        // Anyways, in these games it is better to have the tb define the outcome.
+        None
     }
 
     /// Play a single move, updating all game state.
@@ -157,16 +165,6 @@ impl SelfPlayGame {
         if self.position_counts.get(&hash).copied().unwrap_or(0) >= 2 {
             return true;
         }
-        if self.board.halfmove_clock() == 0 {
-            if let Some(tb) = self.tablebases.as_ref() {
-                if let Some(
-                    WdlProbeResult::Draw | WdlProbeResult::CursedWin | WdlProbeResult::BlessedLoss,
-                ) = search::tablebase::probe_wdl(tb, &self.board)
-                {
-                    return true;
-                }
-            }
-        }
         false
     }
 
@@ -180,22 +178,7 @@ impl SelfPlayGame {
             .collect()
     }
 
-    pub fn get_samples(&mut self) -> (Vec<Sample>, Vec<i16>) {
-        let outcome = self.outcome();
-        let (samples, scores): (Vec<_>, Vec<_>) = self
-            .positions
-            .drain(..)
-            .map(|(fen, score, best_move)| {
-                let sample = Sample {
-                    fen,
-                    score,
-                    game_id: self.game_id,
-                    best_move,
-                    outcome,
-                };
-                (sample, score)
-            })
-            .unzip();
-        (samples, scores)
+    pub fn into_positions(self) -> Vec<Position> {
+        self.positions
     }
 }

--- a/training/src/bin/generate/generator.rs
+++ b/training/src/bin/generate/generator.rs
@@ -1,6 +1,7 @@
 use crate::game::GameConfig;
 use crate::histogram::ScoreHistogram;
 use crate::opening::OpeningSource;
+use crate::refinery::RefinementStats;
 use crate::samples::Sample;
 use crate::worker::SelfPlayWorker;
 use candle_core::Device;
@@ -113,14 +114,18 @@ impl Generator {
         let progress_handle =
             Self::spawn_progress_updater(sample_counter, histogram, Arc::clone(&stop_flag));
 
-        // Wait for all workers to complete
-        let samples: Vec<_> = worker_handles
-            .into_iter()
-            .flat_map(|h| h.join().unwrap())
-            .collect();
+        let mut samples = Vec::new();
+        let mut refinery_stats = RefinementStats::default();
+        for handle in worker_handles {
+            let (worker_samples, worker_stats) = handle.join().unwrap();
+            samples.extend(worker_samples);
+            refinery_stats.merge(&worker_stats);
+        }
 
         stop_flag.store(true, Ordering::Relaxed);
         progress_handle.join().unwrap();
+
+        refinery_stats.log_summary();
 
         samples
     }

--- a/training/src/bin/generate/main.rs
+++ b/training/src/bin/generate/main.rs
@@ -4,6 +4,7 @@ mod generator;
 mod histogram;
 mod limit;
 mod opening;
+mod refinery;
 mod samples;
 mod worker;
 

--- a/training/src/bin/generate/refinery.rs
+++ b/training/src/bin/generate/refinery.rs
@@ -1,0 +1,183 @@
+use crate::game::Position;
+use crate::samples::{GameOutcome, Sample};
+use cozy_chess::Board;
+use pyrrhic_rs::{TableBases, WdlProbeResult};
+use search::{CozyAdapter, tablebase};
+
+/// Position/sample cleanup:
+/// - re-label outcomes based on tb
+/// - TODO: eval / outcome disagreements
+pub struct Refinery {
+    tablebases: Option<TableBases<CozyAdapter>>,
+    stats: RefinementStats,
+}
+
+#[derive(Default, Clone, Copy)]
+pub struct RefinementStats {
+    /// Number of games entering tb range and got labels from it.
+    games_labeled_by_tb: usize,
+    /// Games where the tb outcome changed between probes
+    /// (basically a thrown win/draw somewhere in tb range).
+    games_with_tb_deviations: usize,
+}
+
+impl RefinementStats {
+    pub fn merge(&mut self, other: &RefinementStats) {
+        self.games_labeled_by_tb += other.games_labeled_by_tb;
+        self.games_with_tb_deviations += other.games_with_tb_deviations;
+    }
+
+    pub fn log_summary(&self) {
+        if self.games_labeled_by_tb > 0 {
+            log::info!(
+                "TB outcomes: {} games labeled from tablebases, {} with deviations ({:.2}%)",
+                self.games_labeled_by_tb,
+                self.games_with_tb_deviations,
+                self.games_with_tb_deviations as f64 * 100.0 / self.games_labeled_by_tb as f64,
+            );
+        }
+    }
+}
+
+impl Refinery {
+    pub fn new(tablebases: Option<TableBases<CozyAdapter>>) -> Self {
+        Self {
+            tablebases,
+            stats: RefinementStats::default(),
+        }
+    }
+
+    pub fn stats(&self) -> RefinementStats {
+        self.stats
+    }
+
+    pub fn refine(
+        &mut self,
+        game_id: usize,
+        positions: Vec<Position>,
+        proven_outcome: Option<GameOutcome>,
+    ) -> Vec<Sample> {
+        let tb_outcomes: Vec<Option<GameOutcome>> =
+            positions.iter().map(|p| self.tb_probe(p)).collect();
+
+        let (outcomes, stats) = resolve_outcomes(&tb_outcomes, proven_outcome);
+
+        self.stats.merge(&stats);
+
+        positions
+            .into_iter()
+            .zip(outcomes)
+            .map(|(position, outcome)| Sample {
+                fen: position.fen,
+                score: position.score,
+                game_id,
+                best_move: position.best_move,
+                outcome,
+            })
+            .collect()
+    }
+
+    fn tb_probe(&self, position: &Position) -> Option<GameOutcome> {
+        let board: Board = position.fen.parse().ok()?;
+        if board.halfmove_clock() != 0 {
+            return None;
+        }
+
+        let tb = self.tablebases.as_ref()?;
+        let wdl = tablebase::probe_wdl(tb, &board)?;
+
+        Some(match wdl {
+            WdlProbeResult::Win => GameOutcome::win(board.side_to_move()),
+            WdlProbeResult::Loss => GameOutcome::win(!board.side_to_move()),
+            _ => GameOutcome::Draw,
+        })
+    }
+}
+
+/// Each position gets the tb outcome of the next probe.
+///
+/// NB! If the outcome is speculative (50-move rule, repetition), then we
+/// use the last tb outcome for the remainder of the game. That way a won
+/// game shuffling/teleporting into a draw still gets labeled as a win.
+fn resolve_outcomes(
+    tb_outcomes: &[Option<GameOutcome>],
+    proven_outcome: Option<GameOutcome>,
+) -> (Vec<GameOutcome>, RefinementStats) {
+    let last_tb_outcome = tb_outcomes.iter().flatten().last().copied();
+
+    let mut outcome = proven_outcome
+        .or(last_tb_outcome)
+        .unwrap_or(GameOutcome::Draw);
+
+    let mut outcomes = vec![outcome; tb_outcomes.len()];
+    for (resolved, tb_outcome) in outcomes.iter_mut().zip(tb_outcomes).rev() {
+        if let Some(tb_outcome) = tb_outcome {
+            outcome = *tb_outcome;
+        }
+        *resolved = outcome;
+    }
+
+    let known: Vec<_> = tb_outcomes.iter().flatten().collect();
+    let deviated = known.windows(2).any(|pair| pair[0] != pair[1]);
+
+    let stats = RefinementStats {
+        games_labeled_by_tb: last_tb_outcome.is_some() as usize,
+        games_with_tb_deviations: deviated as usize,
+    };
+
+    (outcomes, stats)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use GameOutcome::{Black, Draw, White};
+
+    #[test]
+    fn game_outside_the_tables_is_a_rule_draw() {
+        let (outcomes, stats) = resolve_outcomes(&[None; 3], None);
+
+        assert_eq!(outcomes, [Draw, Draw, Draw]);
+        assert_eq!(stats.games_labeled_by_tb, 0);
+        assert_eq!(stats.games_with_tb_deviations, 0);
+    }
+
+    #[test]
+    fn mate_on_the_board_labels_everything() {
+        let (outcomes, _) = resolve_outcomes(&[None; 3], Some(White));
+
+        assert_eq!(outcomes, [White, White, White]);
+    }
+
+    #[test]
+    fn tb_outcome_covers_the_positions_leading_up_to_it() {
+        let (outcomes, stats) = resolve_outcomes(&[None, None, Some(White), None], None);
+
+        assert_eq!(outcomes, [White, White, White, White]);
+        assert_eq!(stats.games_labeled_by_tb, 1);
+        assert_eq!(stats.games_with_tb_deviations, 0);
+    }
+
+    #[test]
+    fn won_game_shuffled_into_repetition_is_still_a_win() {
+        let (outcomes, _) = resolve_outcomes(&[Some(Black), None, None], None);
+
+        assert_eq!(outcomes, [Black, Black, Black]);
+    }
+
+    #[test]
+    fn thrown_win_splits_the_game_into_spans() {
+        let (outcomes, stats) =
+            resolve_outcomes(&[None, Some(White), None, Some(Draw), None], None);
+
+        assert_eq!(outcomes, [White, White, Draw, Draw, Draw]);
+        assert_eq!(stats.games_with_tb_deviations, 1);
+    }
+
+    #[test]
+    fn blunder_after_the_last_probe_trumps_the_tables() {
+        let (outcomes, _) = resolve_outcomes(&[Some(Draw), None, None], Some(Black));
+
+        assert_eq!(outcomes, [Draw, Black, Black]);
+    }
+}

--- a/training/src/bin/generate/samples.rs
+++ b/training/src/bin/generate/samples.rs
@@ -1,4 +1,4 @@
-use cozy_chess::Move;
+use cozy_chess::{Color, Move};
 use nnue::network::CP_BOUND;
 use std::fmt;
 use std::io::{self, Write};
@@ -8,6 +8,15 @@ pub enum GameOutcome {
     White,
     Draw,
     Black,
+}
+
+impl GameOutcome {
+    pub fn win(color: Color) -> Self {
+        match color {
+            Color::White => GameOutcome::White,
+            Color::Black => GameOutcome::Black,
+        }
+    }
 }
 
 impl fmt::Display for GameOutcome {

--- a/training/src/bin/generate/worker.rs
+++ b/training/src/bin/generate/worker.rs
@@ -1,6 +1,7 @@
 use crate::game::{GameConfig, SelfPlayGame};
 use crate::histogram::HistogramHandle;
 use crate::opening::OpeningSource;
+use crate::refinery::{RefinementStats, Refinery};
 use crate::samples::Sample;
 use config::EngineConfig;
 use pyrrhic_rs::TableBases;
@@ -22,7 +23,7 @@ pub struct SelfPlayWorker {
     max_games: Option<usize>,
     opening_source: Arc<OpeningSource>,
     histogram: HistogramHandle,
-    tablebases: Option<TableBases<CozyAdapter>>,
+    refinery: Refinery,
 }
 
 impl SelfPlayWorker {
@@ -61,12 +62,12 @@ impl SelfPlayWorker {
             engine,
             opening_source,
             histogram,
-            tablebases,
+            refinery: Refinery::new(tablebases),
         }
     }
 
-    pub fn play_games(&mut self, stop_flag: Arc<AtomicBool>) -> Vec<Sample> {
-        let mut evaluations = Vec::new();
+    pub fn play_games(&mut self, stop_flag: Arc<AtomicBool>) -> (Vec<Sample>, RefinementStats) {
+        let mut samples = Vec::new();
 
         while !stop_flag.load(Ordering::Relaxed) {
             let game_id = self.game_id_counter.fetch_add(1, Ordering::Relaxed);
@@ -79,24 +80,27 @@ impl SelfPlayWorker {
 
             let opening = self.opening_source.next_opening();
 
-            let mut game =
-                SelfPlayGame::new(game_id, opening, self.game_config, self.tablebases.clone());
+            let mut game = SelfPlayGame::new(opening, self.game_config);
             game.play(&mut self.engine);
 
-            let (samples, scores) = game.get_samples();
-            self.record_statistics(&samples, scores);
+            let outcome = game.outcome();
+            let refined = self
+                .refinery
+                .refine(game_id, game.into_positions(), outcome);
 
-            evaluations.extend(samples);
+            self.record_statistics(&refined);
+
+            samples.extend(refined);
         }
 
-        evaluations
+        (samples, self.refinery.stats())
     }
 
-    fn record_statistics(&self, samples: &[Sample], scores: Vec<i16>) {
-        let num_samples = samples.len();
+    fn record_statistics(&self, samples: &[Sample]) {
+        let scores: Vec<i16> = samples.iter().map(|s| s.score).collect();
 
         self.histogram.record_scores(&scores);
         self.sample_counter
-            .fetch_add(num_samples, Ordering::Relaxed);
+            .fetch_add(samples.len(), Ordering::Relaxed);
     }
 }


### PR DESCRIPTION
Was watching a CCRL match and chatting with the Pawnoccio creator about a wcb fortress where grail still had +13 (the game was theoretically drawn). He suggested re-label outcomes from tb wdl after the game instead of just leaning on tb during search.

Sounded reasonable. Checked the position and grail would literally lose to itself in datagen there, even if the game should have been a draw.

This PR adds a post-game refinement pipeline that probes Syzygy WDL and re-labels samples.

500k sample test with the current best net:

```
00:14:52 [INFO] TB outcomes: 1855 games labeled from tablebases, 5 with deviations (0.27%)
00:14:52 [INFO] Generated 505667 samples
```

5 deviations out of 1855 where the datagen is throwing shuffling out of the tb outcome like an idiot.

I also have plans for a system that adjusts "wrong direction eval vs outcome", but that is future. 