### PR TITLE
chore: added eval/outcome disagreement script

### DIFF
--- a/scripts/eval_outcome_disagreement.py
+++ b/scripts/eval_outcome_disagreement.py
@@ -70,7 +70,6 @@ def main():
     print(f"draw + |score| > T:    {draw_disagreements:,} ({100 * draw_disagreements / total:.3f}%)")
     print(f"decisive + opposite:   {decisive_disagreements:,} ({100 * decisive_disagreements / total:.3f}%)")
     print(f"total disagreements:   {disagreements:,} ({100 * disagreements / total:.3f}%)")
-    print(f"of draws disagreeing:  {100 * draw_disagreements / draws:.3f}%")
 
     print_examples("Draw disagreements", draw_hits, draw_disagreements)
     print_examples("Decisive opposites", decisive_hits, decisive_disagreements)

--- a/scripts/eval_outcome_disagreement.py
+++ b/scripts/eval_outcome_disagreement.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Quick look at eval vs outcome disagreements in datagen CSVs.
+
+Usage:
+  python3 scripts/eval_outcome_disagreement.py
+  python3 scripts/eval_outcome_disagreement.py -t 600
+  python3 scripts/eval_outcome_disagreement.py -t 800 nnue/data/*.csv
+"""
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+
+EXAMPLES = 5
+
+FEN = "fen"
+SCORE = "score"
+OUTCOME = "outcome"
+
+WHITE = "W"
+BLACK = "B"
+DRAW = "D"
+
+THRESHOLD = 600
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("files", nargs="*", type=Path)
+    parser.add_argument("-t", "--threshold", type=int, default=THRESHOLD)
+    args = parser.parse_args()
+
+    files = args.files or sorted(Path("nnue/data").glob("*.csv"))
+    threshold = args.threshold
+
+    total = 0
+    draws = 0
+    draw_disagreements = 0
+    decisive_disagreements = 0
+    hits = []
+
+    for path in files:
+        df = pd.read_csv(path, usecols=[FEN, SCORE, OUTCOME])
+        total += len(df)
+
+        is_draw = df[OUTCOME] == DRAW
+        draws += int(is_draw.sum())
+
+        # draw, but eval is way off
+        high_eval_draw = is_draw & (df[SCORE].abs() > threshold)
+
+        # game was decisive, but eval strongly favored the other side
+        white_won_but_eval_black = (df[OUTCOME] == WHITE) & (df[SCORE] < -threshold)
+        black_won_but_eval_white = (df[OUTCOME] == BLACK) & (df[SCORE] > threshold)
+        opposite_eval = white_won_but_eval_black | black_won_but_eval_white
+
+        draw_disagreements += int(high_eval_draw.sum())
+        decisive_disagreements += int(opposite_eval.sum())
+        hits.append(df.loc[high_eval_draw | opposite_eval, [SCORE, OUTCOME, FEN]])
+
+    disagreements = draw_disagreements + decisive_disagreements
+
+    print(f"files:                 {len(files)}")
+    print(f"threshold:             {threshold} cp")
+    print(f"total samples:         {total:,}")
+    print(f"draws:                 {draws:,} ({100 * draws / total:.3f}%)")
+    print(f"draw + |score| > T:    {draw_disagreements:,} ({100 * draw_disagreements / total:.3f}%)")
+    print(f"decisive + opposite:   {decisive_disagreements:,} ({100 * decisive_disagreements / total:.3f}%)")
+    print(f"total disagreements:   {disagreements:,} ({100 * disagreements / total:.3f}%)")
+    print(f"of draws disagreeing:  {100 * draw_disagreements / draws:.3f}%")
+
+    if disagreements:
+        examples = pd.concat(hits).sample(n=min(EXAMPLES, disagreements))
+        print("\nexamples:")
+        for row in examples.itertuples(index=False):
+            print(f"  {int(row.score):+5d}  {row.outcome}  {row.fen}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/eval_outcome_disagreement.py
+++ b/scripts/eval_outcome_disagreement.py
@@ -38,7 +38,8 @@ def main():
     draws = 0
     draw_disagreements = 0
     decisive_disagreements = 0
-    hits = []
+    draw_hits = []
+    decisive_hits = []
 
     for path in files:
         df = pd.read_csv(path, usecols=[FEN, SCORE, OUTCOME])
@@ -57,7 +58,8 @@ def main():
 
         draw_disagreements += int(high_eval_draw.sum())
         decisive_disagreements += int(opposite_eval.sum())
-        hits.append(df.loc[high_eval_draw | opposite_eval, [SCORE, OUTCOME, FEN]])
+        draw_hits.append(df.loc[high_eval_draw, [SCORE, OUTCOME, FEN]])
+        decisive_hits.append(df.loc[opposite_eval, [SCORE, OUTCOME, FEN]])
 
     disagreements = draw_disagreements + decisive_disagreements
 
@@ -70,11 +72,18 @@ def main():
     print(f"total disagreements:   {disagreements:,} ({100 * disagreements / total:.3f}%)")
     print(f"of draws disagreeing:  {100 * draw_disagreements / draws:.3f}%")
 
-    if disagreements:
-        examples = pd.concat(hits).sample(n=min(EXAMPLES, disagreements))
-        print("\nexamples:")
-        for row in examples.itertuples(index=False):
-            print(f"  {int(row.score):+5d}  {row.outcome}  {row.fen}")
+    print_examples("Draw disagreements", draw_hits, draw_disagreements)
+    print_examples("Decisive opposites", decisive_hits, decisive_disagreements)
+
+
+def print_examples(title, hits, count):
+    if not count:
+        return
+
+    examples = pd.concat(hits).sample(n=min(EXAMPLES, count))
+    print(f"\n{title}:")
+    for row in examples.itertuples(index=False):
+        print(f"  {int(row.score):+5d}  {row.outcome}  {row.fen}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
My efforts in #223 didn't work quite as I wanted. I added a small Python script to have a look at how the evals and outcomes are disagreeing. From a batch of #222 data:

```
files:                 4
threshold:             600 cp
total samples:         83,040,735
draws:                 30,442,307 (36.659%)
draw + |score| > T:    766,221 (0.923%)
decisive + opposite:   62,229 (0.075%)
total disagreements:   828,450 (0.998%)

Draw disagreements:
   +718  D  8/8/2B2K2/8/6k1/8/4N3/8 w - - 48 80
   -922  D  8/8/8/p7/8/k4b2/8/1K6 w - - 22 83
   -766  D  r1b2rk1/ppp3pp/3b4/3p4/3q1pP1/5P1N/PP2P1QP/R1BRK3 b - - 1 20
   -620  D  8/P5R1/8/5P2/5r1p/1K3b1k/8/8 w - - 1 96
   +631  D  8/4k3/3R4/r3BK2/8/8/8/8 b - - 78 100

Decisive opposites:
   +614  B  2r3k1/p7/5p1p/2P2Pnq/1N1P3b/P1NQ4/3K4/5R2 b - - 1 34
   -716  W  r2q2k1/2p2rpp/5n2/3p1p2/1P1PpP2/BQN1P2P/3K1nP1/5BR1 b - - 6 24
   -697  W  3r4/7R/3bpk1p/P2p1p1P/3P3p/3BP2K/r4P2/1R6 b - - 2 37
   -739  W  3r1rk1/ppp2ppp/6b1/2b1N3/PnB3Pq/NP2p2P/1BPPRnQ1/R1K5 w - - 0 20
   +875  B  3r4/pp3k2/2n2q2/2PpnB1R/Q1p1p3/2P1B3/PP2PP2/2K5 w - - 3 26
```