### PR TITLE
feat: cap datagen teleport length to a fraction of the PV

### DIFF
--- a/scripts/eval_outcome_disagreement.py
+++ b/scripts/eval_outcome_disagreement.py
@@ -63,13 +63,13 @@ def main():
 
     disagreements = draw_disagreements + decisive_disagreements
 
-    print(f"files:                 {len(files)}")
-    print(f"threshold:             {threshold} cp")
-    print(f"total samples:         {total:,}")
-    print(f"draws:                 {draws:,} ({100 * draws / total:.3f}%)")
-    print(f"draw + |score| > T:    {draw_disagreements:,} ({100 * draw_disagreements / total:.3f}%)")
-    print(f"decisive + opposite:   {decisive_disagreements:,} ({100 * decisive_disagreements / total:.3f}%)")
-    print(f"total disagreements:   {disagreements:,} ({100 * disagreements / total:.3f}%)")
+    print(f"Files:                 {len(files)}")
+    print(f"Threshold:             {threshold} cp")
+    print(f"Total samples:         {total:,}")
+    print(f"Draws:                 {draws:,} ({100 * draws / total:.3f}%)")
+    print(f"Draw disagreements:    {draw_disagreements:,} ({100 * draw_disagreements / total:.3f}%)")
+    print(f"Decisive opposites:    {decisive_disagreements:,} ({100 * decisive_disagreements / total:.3f}%)")
+    print(f"Total disagreements:   {disagreements:,} ({100 * disagreements / total:.3f}%)")
 
     print_examples("Draw disagreements", draw_hits, draw_disagreements)
     print_examples("Decisive opposites", decisive_hits, decisive_disagreements)

--- a/training/src/bin/generate/args.rs
+++ b/training/src/bin/generate/args.rs
@@ -1,4 +1,5 @@
 use clap::{Parser, Subcommand};
+use std::ops::RangeInclusive;
 
 #[derive(Parser, Debug)]
 #[command(name = "NNUE Data Generator")]
@@ -29,9 +30,13 @@ pub struct Args {
     #[arg(long, global = true)]
     pub max_opening_imbalance: Option<i16>,
 
-    /// Max plies to teleport along a PV between recorded positions.
+    /// Max plies of the PV allowed when teleporting.
     #[arg(long, global = true, default_value_t = 8, value_parser = clap::value_parser!(u64).range(1..))]
     pub max_teleport_plies: u64,
+
+    /// Max fraction of the PV length allowed when teleporting.
+    #[arg(long, global = true, default_value_t = 0.5, value_parser = |s: &str| parse_f64_range(s, 0.0..=1.0))]
+    pub max_teleport_pv_fraction: f64,
 
     /// Discard games lasting longer than this many plies
     #[arg(long, global = true, default_value_t = 300, value_parser = clap::value_parser!(u64).range(1..))]
@@ -69,4 +74,17 @@ pub enum Opening {
         #[arg(long, default_value_t = 8)]
         plies: usize,
     },
+}
+
+// Clap doesnt have a range parser for f64.
+fn parse_f64_range(s: &str, range: RangeInclusive<f64>) -> Result<f64, String> {
+    let value: f64 = s.parse().map_err(|e| format!("{e}"))?;
+    if !range.contains(&value) {
+        return Err(format!(
+            "must be between {} and {}, got {value}",
+            range.start(),
+            range.end()
+        ));
+    }
+    Ok(value)
 }

--- a/training/src/bin/generate/game.rs
+++ b/training/src/bin/generate/game.rs
@@ -11,8 +11,15 @@ pub struct GameConfig {
     pub limit: SearchLimit,
     pub max_opening_imbalance: Option<i16>,
     pub max_teleport_plies: usize,
+    pub max_teleport_pv_fraction: f64,
     pub max_game_plies: usize,
     pub dense_sampling: bool,
+}
+impl GameConfig {
+    fn max_teleport_len(&self, pv_len: usize) -> usize {
+        let pv_cap = ((pv_len as f64) * self.max_teleport_pv_fraction).floor() as usize;
+        self.max_teleport_plies.min(pv_cap.max(1))
+    }
 }
 
 /// A recorded position/sample (outcomes are labelled in the refinery).
@@ -86,7 +93,8 @@ impl SelfPlayGame {
 
                 if is_anchor {
                     let chosen = result.select_softmax().expect("has lines");
-                    let len = rng().random_range(1..=self.config.max_teleport_plies);
+                    let max_len = self.config.max_teleport_len(chosen.line.len());
+                    let len = rng().random_range(1..=max_len);
                     line = chosen.line.iter().take(len).copied().collect();
                 }
             }

--- a/training/src/bin/generate/main.rs
+++ b/training/src/bin/generate/main.rs
@@ -54,6 +54,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         limit,
         max_opening_imbalance: args.max_opening_imbalance,
         max_teleport_plies: args.max_teleport_plies as usize,
+        max_teleport_pv_fraction: args.max_teleport_pv_fraction,
         max_game_plies: args.max_game_plies as usize,
         dense_sampling: !args.sparse_samples,
     };


### PR DESCRIPTION
## Summary

Trying to solve the findings in #224.

Tested an idea I had to cap the datagen teleporting to a fraction of the PV line. I currently cap the max teleport plies to 8 by default, but if the PV itself is 8 or less it can still pick the last move of the line. I have a hunch that these moves are super risky to let roll out, since there is very little search put into these as the robustness of the eval tapers off as the PV goes on.

I tried adding an additional constraint of 50% of the PV and compared with the current 100% on 10k games each:

### Before (100%)

```
./target/release/generate random --plies 8 --max-teleport-pv-fraction 1.0 --nodes 10000 --max-opening-imbalance 600 --max-games 10000 --syzygy-path "$HOME/syzygy/3-4-5:$HOME/syzygy/6-WDL"
```

```
22:02:15 [INFO] TB outcomes: 4569 games labeled from tablebases, 21 with deviations (0.46%)
22:02:15 [INFO] Generated 1265458 samples
22:02:15 [INFO] Writing samples to nnue/data/2026-07-10-00:02.csv
```

```
Files:                 1
Threshold:             600 cp
Total samples:         1,265,458
Draws:                 427,568 (33.788%)
Draw disagreements:    12,063 (0.953%)
Decisive opposites:    619 (0.049%)
Total disagreements:   12,682 (1.002%)

Draw disagreements:
  -1629  D  2B5/p7/P3k3/8/8/8/5PK1/3q4 b - - 13 70
   +657  D  4k3/2r4p/5R1P/8/5N2/3b4/1K6/8 w - - 0 54
   -654  D  5rk1/8/1R2br1p/6p1/1Q1pP1P1/3Pq1BP/2P3BK/8 b - - 10 45
  -1296  D  8/R3bk1p/6p1/3b4/2p2PP1/pp3P1P/2PP4/1K6 w - - 3 43
   +683  D  r1b4r/4k1pq/pppNpp2/8/6P1/P1Q1b2P/1P4B1/3R1R1K b - - 1 30

Decisive opposites:
  +1635  B  5rk1/1pp2p2/2n2Qp1/4p1P1/p7/2P3q1/PP2R3/2K4R b - - 1 29
   -878  W  4r2r/1pk3pp/n1p5/4PnN1/pb6/1P3NPP/P1P5/1K1RR3 w - - 5 19
  -1013  W  7k/p3r3/5n2/6R1/2PpBp2/1P1P4/Pb2K3/8 b - - 0 39
   -630  W  r5k1/5pb1/1RN1pn1p/3p4/r1pP4/2B1PKP1/p2P3P/R7 w - - 1 28
   -769  W  2b2rk1/2p1q3/pr2p1Qp/7n/2B2b1P/2N5/1PP5/1K1R1R2 b - - 0 26
```

```
22:04:03 [INFO] Total samples: 1265458
22:04:03 [INFO] Unique positions: ~99.80%
22:04:03 [INFO] Total games: 9198
22:04:03 [INFO] Outcomes: white 33.0% / draw 33.8% / black 33.3%
22:04:03 [INFO] Output bucket distribution:
22:04:03 [INFO]   Bucket 0: 97947 samples (7.7%)
22:04:03 [INFO]   Bucket 1: 257476 samples (20.3%)
22:04:03 [INFO]   Bucket 2: 209614 samples (16.6%)
22:04:03 [INFO]   Bucket 3: 161757 samples (12.8%)
22:04:03 [INFO]   Bucket 4: 134232 samples (10.6%)
22:04:03 [INFO]   Bucket 5: 131497 samples (10.4%)
22:04:03 [INFO]   Bucket 6: 139491 samples (11.0%)
22:04:03 [INFO]   Bucket 7: 133444 samples (10.5%)
```

### After (50%)

```
./target/release/generate random --plies 8 --max-teleport-pv-fraction 0.5 --nodes 10000 --max-opening-imbalance 600 --max-games 10000 --syzygy-path "$HOME/syzygy/3-4-5:$HOME/syzygy/6-WDL"
```

```
22:18:20 [INFO] TB outcomes: 4673 games labeled from tablebases, 18 with deviations (0.39%)
22:18:20 [INFO] Generated 1314059 samples
22:18:20 [INFO] Writing samples to nnue/data/2026-07-10-00:18.csv
```

```
Files:                 1
Threshold:             600 cp
Total samples:         1,314,059
Draws:                 487,040 (37.064%)
Draw disagreements:    9,196 (0.700%)
Decisive opposites:    493 (0.038%)
Total disagreements:   9,689 (0.737%)

Draw disagreements:
  -4065  D  8/4R3/5k2/1p1p1n2/8/6r1/5r2/7K w - - 2 50
  -1155  D  8/2p5/Kb6/1P1R4/1k6/8/2r5/8 b - - 39 112
   +685  D  8/3kn3/p5p1/2K1B2p/1P4PP/5P2/8/8 w - - 5 70
  +1160  D  k7/8/1K6/8/P2B4/8/8/8 b - - 12 54
   +953  D  8/1p6/8/P3NR2/4P2k/5K2/r4P2/3b4 w - - 5 48

Decisive opposites:
   -743  W  8/p6r/1p2pk2/2p1bpp1/P7/1P1P1P2/2P3K1/4RN2 w - - 18 41
   +778  B  r3qk1r/2N3p1/bpNp4/2bP1pPp/p3P2P/PnB2Q2/1P4n1/1K1RR3 b - - 0 27
   -705  W  8/8/4pk2/1pp2pp1/5b1r/1P1P1P2/2P1R1K1/5N2 w - - 0 55
  -1256  W  k1B1r3/2R5/2pB2p1/1p1b4/1P1P3P/p3K3/8/r7 w - - 4 58
  +1653  B  6Q1/1p4p1/2bq2kp/8/3pP2P/5BP1/7K/8 w - - 2 44
```

```
22:29:03 [INFO] Total samples: 1314059
22:29:03 [INFO] Unique positions: ~100.05%
22:29:03 [INFO] Total games: 9107
22:29:03 [INFO] Outcomes: white 30.9% / draw 37.1% / black 32.0%
22:29:03 [INFO] Output bucket distribution:
22:29:03 [INFO]   Bucket 0: 115878 samples (8.8%)
22:29:03 [INFO]   Bucket 1: 273096 samples (20.8%)
22:29:03 [INFO]   Bucket 2: 213739 samples (16.3%)
22:29:03 [INFO]   Bucket 3: 161174 samples (12.3%)
22:29:03 [INFO]   Bucket 4: 136208 samples (10.4%)
22:29:03 [INFO]   Bucket 5: 132447 samples (10.1%)
22:29:03 [INFO]   Bucket 6: 144116 samples (11.0%)
22:29:03 [INFO]   Bucket 7: 137401 samples (10.5%)
```