### PR TITLE
ci: add aarch64 release build (for Android)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,18 @@ jobs:
       - run: rustup target add ${{ matrix.rust_target }}
       - run: rustup component add llvm-tools-preview
 
+      # FIXME: candle drags in onig_sys (C code), which needs a musl C compiler here.
+      # The engine only uses candle to load the safetensors weights at startup, so I
+      # could refactor to load them with the safetensors crate directly and drop
+      # candle from the engine entirely... Then this step should go away.
+      - name: Install musl toolchain
+        if: endsWith(matrix.rust_target, '-musl')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+          echo "CC_aarch64_unknown_linux_musl=musl-gcc" >> "$GITHUB_ENV"
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc" >> "$GITHUB_ENV"
+
       - name: PGO build
         shell: bash
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,14 @@ jobs:
             cpu: x86-64-v3
             pgo_cpu: x86-64-v3
             binary_name: grail-x86-64-v3
+          # Static musl build for Android (https://github.com/jorgenhanssen/grail/issues/227).
+          # TODO: switch to ubuntu-arm-latest when GitHub invents it.......
+          - os: ubuntu-24.04-arm
+            name: linux
+            rust_target: aarch64-unknown-linux-musl
+            cpu: generic
+            pgo_cpu: generic
+            binary_name: grail-aarch64
 
           # Windows builds
           - os: windows-latest
@@ -113,6 +121,7 @@ jobs:
           mkdir -p package-linux
           cp artifacts/linux-grail-x86-64-v3/grail-x86-64-v3 package-linux/
           cp artifacts/linux-grail-x86-64-v4/grail-x86-64-v4 package-linux/
+          cp artifacts/linux-grail-aarch64/grail-aarch64 package-linux/
           chmod +x package-linux/*
 
       - name: Package Windows binaries
@@ -151,6 +160,7 @@ jobs:
           name: |
             linux-grail-x86-64-v3
             linux-grail-x86-64-v4
+            linux-grail-aarch64
             windows-grail-x86-64-v3
             windows-grail-x86-64-v4
             macos-grail-arm64

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,8 +1751,7 @@ checksum = "40e24eee682d89fb193496edf918a7f407d30175b2e785fe057e4392dfd182e0"
 [[package]]
 name = "pyrrhic-rs"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3910f053bb86e0d75fb0e61b47d82e456a15c548fb4d8a8da9d9d1a34a4e299"
+source = "git+https://github.com/Algorhythm-sxv/pyrrhic-rs?rev=961c059#961c059c0c06d2d2090cc09e5f300c2ca2c2d62c"
 dependencies = [
  "libc",
  "memmap2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,8 @@ incremental = false
 [profile.profiling]
 inherits = "release"
 debug = true
+
+# crates version of pyrrhic-rs is outdated, and the git version has a fix I need...
+# Fixes an issue with aarch64 builds (needs c_char, but 0.2.0 hardcoded i8).
+[patch.crates-io]
+pyrrhic-rs = { git = "https://github.com/Algorhythm-sxv/pyrrhic-rs", rev = "961c059" }


### PR DESCRIPTION
As requested in https://github.com/jorgenhanssen/grail/issues/227.

## Summary

Added a `grail-aarch64` release binary in the build pipeline. Seems to work as demonstrated by the successfull PGO build: https://github.com/jorgenhanssen/grail/actions/runs/30130258630/job/89602976802