### PR TITLE
chore: migrate from nightly to stable rust

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,9 +63,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
-      - run: rustup default nightly
       - run: rustup target add ${{ matrix.rust_target }}
-      - run: rustup component add llvm-tools-preview
 
       # FIXME: candle drags in onig_sys (C code), which needs a musl C compiler here.
       # The engine only uses candle to load the safetensors weights at startup, so I

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,6 @@ jobs:
       - name: Install plotters system deps
         run: sudo apt-get update && sudo apt-get install -y pkg-config libfreetype6-dev libfontconfig1-dev
 
-      - name: Install Rust nightly
-        uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: rustfmt
-
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1641,6 +1641,7 @@ dependencies = [
  "cozy-chess",
  "log",
  "utils",
+ "wide",
 ]
 
 [[package]]
@@ -2220,6 +2221,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safe_arch"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a52ec151f024d703f9fd65abb7cbe81e7cdb39f18917a3a37e3014470dc7c59"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "safetensors"
@@ -2979,6 +2989,16 @@ dependencies = [
  "env_home",
  "rustix",
  "winsafe",
+]
+
+[[package]]
+name = "wide"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de2aaf408e58689c2096682331b1f42bb2d9f2ed6b11560407d023cd0a6c634e"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CCRL 40/15](https://img.shields.io/badge/CCRL%2040%2F15-3389%20Elo-%23DAA520.svg)](https://computerchess.org.uk/ccrl/4040/cgi/compare_engines.cgi?family=Grail&print=Rating+list)
 [![License: GPL-3.0](https://img.shields.io/badge/License-GPL%203.0-blue.svg)](LICENSE)
-[![Rust](https://img.shields.io/badge/rust-nightly-orange.svg)](https://www.rust-lang.org/)
+[![Rust](https://img.shields.io/badge/rust-stable-orange.svg)](https://www.rust-lang.org/)
 
 Grail is a hobby chess engine written in Rust. It began as an attempt to make a chess engine and has since become an elaborate system for turning my sanity and electricity bill into Elo. It uses modern search techniques and a fully self-taught NNUE trained on 99 million self-play games. The name refers to the Holy Grail, which may still be easier to find than perfect chess.
 
@@ -64,12 +64,12 @@ You can challenge the latest version of Grail on [Lichess](https://lichess.org/@
 
 ### Building from Source
 
-_Grail requires the Rust nightly toolchain (for `portable_simd` and `generic_const_exprs`)!_
+Grail is built on [Rust](https://www.rust-lang.org/tools/install), so make sure you have it installed.
 
 ```bash
 git clone https://github.com/jorgenhanssen/grail.git
 cd grail
-rustup override set nightly
+
 make grail
 ```
 

--- a/nnue/Cargo.toml
+++ b/nnue/Cargo.toml
@@ -14,6 +14,7 @@ cozy-chess = { workspace = true }
 log = { workspace = true }
 candle-core = { workspace = true }
 candle-nn = { workspace = true }
+wide = "1.6.1"
 
 [features]
 default = []

--- a/nnue/src/encoding.rs
+++ b/nnue/src/encoding.rs
@@ -1,5 +1,6 @@
 use cozy_chess::{BitBoard, Board, Color, Piece, Square};
-use utils::bitset::Bitset;
+
+use crate::bitset;
 
 const NUM_PIECE_PLACEMENT_FEATURES: usize = Square::NUM * Piece::NUM * Color::NUM;
 const NUM_SUPPORT_FEATURES: usize = Square::NUM * 2;
@@ -99,8 +100,8 @@ pub fn encode_board_bitset(
     white_threats: BitBoard,
     black_threats: BitBoard,
     perspective: Color,
-) -> Bitset<NUM_FEATURES> {
-    let mut bitset = Bitset::default();
+) -> bitset!(NUM_FEATURES) {
+    let mut bitset: bitset!(NUM_FEATURES) = Default::default();
 
     // Piece placements
     for color in [Color::White, Color::Black] {

--- a/nnue/src/lib.rs
+++ b/nnue/src/lib.rs
@@ -1,9 +1,9 @@
 #![feature(portable_simd)]
-#![feature(generic_const_exprs)]
-#![allow(incomplete_features)]
 
 pub mod encoding;
 pub mod evaluator;
 pub mod network;
 
 pub use evaluator::Evaluator;
+
+pub(crate) use utils::bitset;

--- a/nnue/src/lib.rs
+++ b/nnue/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(portable_simd)]
-
 pub mod encoding;
 pub mod evaluator;
 pub mod network;

--- a/nnue/src/network/accumulator.rs
+++ b/nnue/src/network/accumulator.rs
@@ -3,8 +3,8 @@ use std::simd::prelude::SimdFloat;
 use std::simd::{i8x32, i16x16};
 
 use cozy_chess::Color;
-use utils::bitset::Bitset;
 
+use crate::bitset;
 use crate::encoding::NUM_FEATURES;
 
 use super::simd::{SIMD_WIDTH_F32, SIMD_WIDTH_I16, SimdF32, SimdI16};
@@ -43,8 +43,8 @@ pub struct Accumulator {
     buffer_black: [i16; EMBEDDING_SIZE],
 
     // To know which inputs have changed since the last update
-    previous_white: Bitset<NUM_FEATURES>,
-    previous_black: Bitset<NUM_FEATURES>,
+    previous_white: bitset!(NUM_FEATURES),
+    previous_black: bitset!(NUM_FEATURES),
 
     // Per-neuron weight quantization scale factors to convert it back to f32.
     // USes 1/scale to avoid slower division operations.
@@ -68,8 +68,8 @@ impl Accumulator {
             biases: biases_i16,
             buffer_white,
             buffer_black,
-            previous_white: Bitset::default(),
-            previous_black: Bitset::default(),
+            previous_white: Default::default(),
+            previous_black: Default::default(),
             inv_scales,
         }
     }
@@ -77,12 +77,12 @@ impl Accumulator {
     pub fn reset(&mut self) {
         self.buffer_white.copy_from_slice(&self.biases);
         self.buffer_black.copy_from_slice(&self.biases);
-        self.previous_white = Bitset::default();
-        self.previous_black = Bitset::default();
+        self.previous_white = Default::default();
+        self.previous_black = Default::default();
     }
 
     /// Updates the accumulators based on the difference between previous and current inputs.
-    pub fn update(&mut self, color: Color, new_input: &Bitset<NUM_FEATURES>) {
+    pub fn update(&mut self, color: Color, new_input: &bitset!(NUM_FEATURES)) {
         let previous = match color {
             Color::White => self.previous_white,
             Color::Black => self.previous_black,

--- a/nnue/src/network/accumulator.rs
+++ b/nnue/src/network/accumulator.rs
@@ -1,5 +1,5 @@
 use cozy_chess::Color;
-use wide::{f32x16, i8x32, i16x16};
+use wide::{f32x16, i8x32, i16x16, i16x32};
 
 use crate::bitset;
 use crate::encoding::NUM_FEATURES;
@@ -107,7 +107,7 @@ impl Accumulator {
         for i in (0..EMBEDDING_SIZE).step_by(SIMD_WIDTH_I16) {
             let mut buffer_vec = SimdI16::new(buffer[i..i + SIMD_WIDTH_I16].try_into().unwrap());
             let weights_i8 = i8x32::new(weights_row[i..i + SIMD_WIDTH_I16].try_into().unwrap());
-            let weights_i16 = weights_i8.widening_mul(i8x32::splat(1));
+            let weights_i16 = i16x32::new(weights_i8.to_array().map(|x| x as i16));
 
             if add {
                 buffer_vec += weights_i16;
@@ -131,7 +131,7 @@ impl Accumulator {
 
         for i in (0..EMBEDDING_SIZE).step_by(SIMD_WIDTH_F32) {
             let vals_i16 = i16x16::new(buffer[i..i + SIMD_WIDTH_F32].try_into().unwrap());
-            let vals_f32 = f32x16::new(std::array::from_fn(|j| vals_i16.as_array()[j] as f32));
+            let vals_f32 = f32x16::new(vals_i16.to_array().map(|x| x as f32));
             let scale_vec =
                 SimdF32::new(self.inv_scales[i..i + SIMD_WIDTH_F32].try_into().unwrap());
 

--- a/nnue/src/network/accumulator.rs
+++ b/nnue/src/network/accumulator.rs
@@ -1,8 +1,5 @@
-use std::simd::num::SimdInt;
-use std::simd::prelude::SimdFloat;
-use std::simd::{i8x32, i16x16};
-
 use cozy_chess::Color;
+use wide::{f32x16, i8x32, i16x16};
 
 use crate::bitset;
 use crate::encoding::NUM_FEATURES;
@@ -108,9 +105,9 @@ impl Accumulator {
         };
 
         for i in (0..EMBEDDING_SIZE).step_by(SIMD_WIDTH_I16) {
-            let mut buffer_vec = SimdI16::from_slice(&buffer[i..i + SIMD_WIDTH_I16]);
-            let weights_i8 = i8x32::from_slice(&weights_row[i..i + SIMD_WIDTH_I16]);
-            let weights_i16: SimdI16 = weights_i8.cast();
+            let mut buffer_vec = SimdI16::new(buffer[i..i + SIMD_WIDTH_I16].try_into().unwrap());
+            let weights_i8 = i8x32::new(weights_row[i..i + SIMD_WIDTH_I16].try_into().unwrap());
+            let weights_i16 = weights_i8.widening_mul(i8x32::splat(1));
 
             if add {
                 buffer_vec += weights_i16;
@@ -118,7 +115,7 @@ impl Accumulator {
                 buffer_vec -= weights_i16;
             }
 
-            buffer_vec.copy_to_slice(&mut buffer[i..i + SIMD_WIDTH_I16]);
+            buffer[i..i + SIMD_WIDTH_I16].copy_from_slice(buffer_vec.as_array());
         }
     }
 
@@ -133,13 +130,13 @@ impl Accumulator {
         let zeros = SimdF32::splat(0.0);
 
         for i in (0..EMBEDDING_SIZE).step_by(SIMD_WIDTH_F32) {
-            let vals_f32 = i16x16::from_slice(&buffer[i..i + SIMD_WIDTH_F32]).cast();
-            let scale_vec = SimdF32::from_slice(&self.inv_scales[i..i + SIMD_WIDTH_F32]);
+            let vals_i16 = i16x16::new(buffer[i..i + SIMD_WIDTH_F32].try_into().unwrap());
+            let vals_f32 = f32x16::new(std::array::from_fn(|j| vals_i16.as_array()[j] as f32));
+            let scale_vec =
+                SimdF32::new(self.inv_scales[i..i + SIMD_WIDTH_F32].try_into().unwrap());
 
-            let dequantized = vals_f32 * scale_vec;
-            let activated = dequantized.simd_max(zeros); // ReLU
-
-            activated.copy_to_slice(&mut output[i..i + SIMD_WIDTH_F32]);
+            let activated = (vals_f32 * scale_vec).max(zeros);
+            output[i..i + SIMD_WIDTH_F32].copy_from_slice(activated.as_array());
         }
     }
 }

--- a/nnue/src/network/inference.rs
+++ b/nnue/src/network/inference.rs
@@ -1,7 +1,7 @@
 use candle_core::Result;
 use cozy_chess::Color;
-use utils::bitset::Bitset;
 
+use crate::bitset;
 use crate::encoding::NUM_FEATURES;
 
 use super::accumulator::Accumulator;
@@ -49,8 +49,8 @@ impl NNUENetwork {
 
     pub fn forward(
         &mut self,
-        white_bits: &Bitset<NUM_FEATURES>,
-        black_bits: &Bitset<NUM_FEATURES>,
+        white_bits: &bitset!(NUM_FEATURES),
+        black_bits: &bitset!(NUM_FEATURES),
         stm: Color,
         bucket: usize,
     ) -> f32 {

--- a/nnue/src/network/simd.rs
+++ b/nnue/src/network/simd.rs
@@ -1,5 +1,4 @@
-use std::simd::prelude::SimdFloat;
-use std::simd::{f32x16, i16x32};
+use wide::{f32x16, i16x32};
 
 pub type SimdF32 = f32x16;
 pub type SimdI16 = i16x32;
@@ -13,10 +12,8 @@ pub fn simd_relu(values: &mut [f32]) {
     let zeros = SimdF32::splat(0.0);
 
     while i + SIMD_WIDTH_F32 <= len {
-        let chunk = SimdF32::from_slice(&values[i..i + SIMD_WIDTH_F32]);
-        chunk
-            .simd_max(zeros)
-            .copy_to_slice(&mut values[i..i + SIMD_WIDTH_F32]);
+        let chunk = SimdF32::new(values[i..i + SIMD_WIDTH_F32].try_into().unwrap());
+        values[i..i + SIMD_WIDTH_F32].copy_from_slice(chunk.max(zeros).as_array());
         i += SIMD_WIDTH_F32;
     }
 
@@ -30,9 +27,9 @@ pub fn simd_add(dest: &mut [f32], src: &[f32]) {
     let mut i = 0;
 
     while i + SIMD_WIDTH_F32 <= len {
-        let d = SimdF32::from_slice(&dest[i..i + SIMD_WIDTH_F32]);
-        let s = SimdF32::from_slice(&src[i..i + SIMD_WIDTH_F32]);
-        (d + s).copy_to_slice(&mut dest[i..i + SIMD_WIDTH_F32]);
+        let d = SimdF32::new(dest[i..i + SIMD_WIDTH_F32].try_into().unwrap());
+        let s = SimdF32::new(src[i..i + SIMD_WIDTH_F32].try_into().unwrap());
+        dest[i..i + SIMD_WIDTH_F32].copy_from_slice((d + s).as_array());
         i += SIMD_WIDTH_F32;
     }
 
@@ -46,13 +43,13 @@ pub fn dot_product(a: &[f32], b: &[f32], len: usize) -> f32 {
     let mut i = 0;
 
     while i + SIMD_WIDTH_F32 <= len {
-        let a_vec = SimdF32::from_slice(&a[i..i + SIMD_WIDTH_F32]);
-        let b_vec = SimdF32::from_slice(&b[i..i + SIMD_WIDTH_F32]);
+        let a_vec = SimdF32::new(a[i..i + SIMD_WIDTH_F32].try_into().unwrap());
+        let b_vec = SimdF32::new(b[i..i + SIMD_WIDTH_F32].try_into().unwrap());
         sum_vec += a_vec * b_vec;
         i += SIMD_WIDTH_F32;
     }
 
-    let mut sum = sum_vec.reduce_sum();
+    let mut sum = sum_vec.reduce_add();
     for j in i..len {
         sum += a[j] * b[j];
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.97.1"
+components = ["rustfmt", "llvm-tools-preview"]

--- a/utils/src/bitset.rs
+++ b/utils/src/bitset.rs
@@ -1,13 +1,16 @@
-/// A packed bit array that holds a specific number of bits.
+/// A packed bit array of `WORDS` u64s.
 #[derive(Clone, Copy)]
-pub struct Bitset<const BITS: usize>([u64; BITS.div_ceil(64)])
-where
-    [(); BITS.div_ceil(64)]:;
+pub struct Bitset<const WORDS: usize>([u64; WORDS]);
 
-impl<const BITS: usize> Bitset<BITS>
-where
-    [(); BITS.div_ceil(64)]:,
-{
+/// Creates a new Bitset for a specified number of bits.
+#[macro_export]
+macro_rules! bitset {
+    ($bits:expr) => {
+        $crate::bitset::Bitset<{ ($bits as usize).div_ceil(64) }>
+    };
+}
+
+impl<const WORDS: usize> Bitset<WORDS> {
     /// Set a bit at the given index.
     pub fn set(&mut self, idx: usize) {
         self.0[idx / 64] |= 1u64 << (idx % 64);
@@ -39,7 +42,7 @@ where
     }
 
     /// Get the underlying u64 array.
-    pub fn as_array(&self) -> &[u64; BITS.div_ceil(64)] {
+    pub fn as_array(&self) -> &[u64; WORDS] {
         &self.0
     }
 
@@ -53,21 +56,15 @@ where
             while changes != 0 {
                 let bit_idx = changes.trailing_zeros() as usize;
                 changes &= changes - 1;
-                let idx = word_idx * 64 + bit_idx;
-                if idx < BITS {
-                    f(idx);
-                }
+                f(word_idx * 64 + bit_idx);
             }
         }
     }
 }
 
-impl<const BITS: usize> Default for Bitset<BITS>
-where
-    [(); BITS.div_ceil(64)]:,
-{
+impl<const WORDS: usize> Default for Bitset<WORDS> {
     fn default() -> Self {
-        Self([0; BITS.div_ceil(64)])
+        Self([0; WORDS])
     }
 }
 
@@ -77,7 +74,7 @@ mod tests {
 
     #[test]
     fn test_set_and_get() {
-        let mut bits: Bitset<128> = Bitset::default();
+        let mut bits: bitset!(128) = Bitset::default();
         assert!(!bits.get(0));
         assert!(!bits.get(127));
 
@@ -92,7 +89,7 @@ mod tests {
 
     #[test]
     fn test_unset() {
-        let mut bits: Bitset<64> = Bitset::default();
+        let mut bits: bitset!(64) = Bitset::default();
         bits.set(10);
         assert!(bits.get(10));
 
@@ -102,7 +99,7 @@ mod tests {
 
     #[test]
     fn test_toggle() {
-        let mut bits: Bitset<64> = Bitset::default();
+        let mut bits: bitset!(64) = Bitset::default();
         assert!(!bits.get(5));
 
         bits.toggle(5);
@@ -114,7 +111,7 @@ mod tests {
 
     #[test]
     fn test_cross_word_boundary() {
-        let mut bits: Bitset<128> = Bitset::default();
+        let mut bits: bitset!(128) = Bitset::default();
         bits.set(63);
         bits.set(64);
 
@@ -126,8 +123,8 @@ mod tests {
 
     #[test]
     fn test_for_each_diff() {
-        let mut a: Bitset<128> = Bitset::default();
-        let mut b: Bitset<128> = Bitset::default();
+        let mut a: bitset!(128) = Bitset::default();
+        let mut b: bitset!(128) = Bitset::default();
 
         a.set(0);
         a.set(10);
@@ -147,7 +144,7 @@ mod tests {
 
     #[test]
     fn test_default_is_all_zeros() {
-        let bits: Bitset<256> = Bitset::default();
+        let bits: bitset!(256) = Bitset::default();
         for i in 0..256 {
             assert!(!bits.get(i));
         }
@@ -155,7 +152,7 @@ mod tests {
 
     #[test]
     fn test_u64_index() {
-        let bits: Bitset<256> = Bitset::default();
+        let bits: bitset!(256) = Bitset::default();
         assert_eq!(bits.u64_index(0), 0);
         assert_eq!(bits.u64_index(63), 0);
         assert_eq!(bits.u64_index(64), 1);
@@ -165,7 +162,7 @@ mod tests {
 
     #[test]
     fn test_set_u64() {
-        let mut bits: Bitset<256> = Bitset::default();
+        let mut bits: bitset!(256) = Bitset::default();
         bits.set_u64(1, u64::MAX);
 
         for i in 0..64 {
@@ -181,7 +178,7 @@ mod tests {
 
     #[test]
     fn test_set_u64_specific_pattern() {
-        let mut bits: Bitset<128> = Bitset::default();
+        let mut bits: bitset!(128) = Bitset::default();
         bits.set_u64(0, 0xAAAAAAAAAAAAAAAA);
 
         for i in 0..64 {

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1,6 +1,3 @@
-#![feature(generic_const_exprs)]
-#![allow(incomplete_features)]
-
 mod attacks;
 pub mod bitset;
 pub mod board_metrics;


### PR DESCRIPTION
## Summary

I want to get to a pinned version of stable rust for two reasons:

1. In the wake of https://github.com/jorgenhanssen/grail/issues/227, a reproducable CI rust version that also matches the local one would be nice.
2. The Plotters' TTF `pathfinder_simd` implementation broke locally on my mac because of an old nighty version that hadn't renamed some functions yet:
```
82 |         unsafe { F32x2(simd_minimum_number_nsz(self.0, other.0)) }
   |                        ^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
```

So in this PR:

- Changed Bitset from needing `generic_const_exprs` to using a macro instead.
- Replaced `portable_simd` for the [wide](https://docs.rs/wide/latest/wide/) crate.
- Pin stable 1.97.1 via `rust-toolchain.toml` and stop forcing nightly in CI.

The bench hash has changed slightly (on my mac):

#### Old bench

```
Depth        : 14
Max seldepth : 37
Avg seldepth : 26.8
Total time   : 14017 ms
Total nodes  : 14075904
Avg NPS      : 1004202
Avg branching: 2.39
Bench hash   : 139B24375C3D0B54
```

#### New bench

```
Depth        : 14
Max seldepth : 37
Avg seldepth : 27.0
Total time   : 13463 ms
Total nodes  : 14104576
Avg NPS      : 1047654
Avg branching: 2.39
Bench hash   : 3DB49304441620E4
```