### PR TITLE
perf: tt in qs move ordering

### DIFF
--- a/search/src/move_ordering/main.rs
+++ b/search/src/move_ordering/main.rs
@@ -24,13 +24,6 @@ enum Phase {
 
 /// Staged move generator for main search. Based on Black Marlin.
 ///
-/// Generates and sorts moves lazily in phases to avoid doing it all upfront:
-/// 1. BestMove (TT/PV move) - most likely to cause cutoff
-/// 2. GoodCaptures - winning/equal captures by SEE (includes capture promotions)
-/// 3. GoodQuiets - quiet moves with good score (queen promos first)
-/// 4. BadCaptures - losing captures, tried late
-/// 5. BadQuiets - quiet moves with bad score (underpromos last)
-///
 /// <https://www.chessprogramming.org/Move_Ordering>
 /// <https://github.com/jnlt3/blackmarlin>
 pub struct MainMoveGenerator {
@@ -153,7 +146,6 @@ impl MainMoveGenerator {
                     return Some(scored_move.mov);
                 }
 
-                // Only run expensive SEE if capture seems questionable
                 if !see(board, scored_move.mov, 0) {
                     self.bad_captures.push(scored_move);
                     continue;
@@ -214,7 +206,7 @@ impl MainMoveGenerator {
                                 score += value / self.escape_divisor;
                             }
 
-                            // A valuable piece moving to an attacked square = bad
+                            // Hanging a valuable piece = bad
                             if to_unsafe && value > PAWN_VALUE {
                                 score -= value / self.unsafe_square_divisor;
                             }

--- a/search/src/move_ordering/quiescence.rs
+++ b/search/src/move_ordering/quiescence.rs
@@ -16,15 +16,19 @@ pub struct QMoveGenerator {
 }
 
 impl QMoveGenerator {
-    pub fn new(node: &Node, capture_history: &CaptureHistory) -> Self {
+    pub fn new(node: &Node, capture_history: &CaptureHistory, best_move: Option<Move>) -> Self {
         if node.in_check() {
-            Self::gen_evasions(node)
+            Self::gen_evasions(node, best_move)
         } else {
-            Self::gen_captures(node, capture_history)
+            Self::gen_captures(node, capture_history, best_move)
         }
     }
 
-    fn gen_captures(node: &Node, capture_history: &CaptureHistory) -> Self {
+    fn gen_captures(
+        node: &Node,
+        capture_history: &CaptureHistory,
+        best_move: Option<Move>,
+    ) -> Self {
         let board = node.board();
         let mut forcing_moves = ArrayVec::new();
         let enemy_pieces = board.colors(!board.side_to_move());
@@ -38,8 +42,12 @@ impl QMoveGenerator {
                     return true;
                 }
 
-                // MVV-LVA + capture history: prefer capturing valuable pieces with cheap ones
-                let score = capture_score(board, mov, capture_history);
+                let score = if Some(mov) == best_move {
+                    i16::MAX
+                } else {
+                    // MVV-LVA + capture history: prefer capturing valuable pieces with cheap ones
+                    capture_score(board, mov, capture_history)
+                };
 
                 forcing_moves.push(ScoredMove { mov, score });
             }
@@ -49,7 +57,7 @@ impl QMoveGenerator {
         Self { forcing_moves }
     }
 
-    fn gen_evasions(node: &Node) -> Self {
+    fn gen_evasions(node: &Node, best_move: Option<Move>) -> Self {
         let board = node.board();
         let mut forcing_moves = ArrayVec::new();
 
@@ -59,11 +67,14 @@ impl QMoveGenerator {
                     return true;
                 }
 
-                // Evasion ordering by negated piece value: king (0) first, then
-                // cheapest pieces. This prioritizes safe king escapes and risks
-                // the least valuable material when blocking or capturing.
-                let moved_piece = board.piece_on(mov.from).unwrap();
-                let score: i16 = -piece_value(moved_piece);
+                let score = if Some(mov) == best_move {
+                    i16::MAX
+                } else {
+                    // Evasion ordering by negated piece value: king (0) first, then
+                    // cheapest pieces. This prioritizes safe king escapes and risks
+                    // the least valuable material when blocking or capturing.
+                    -piece_value(board.piece_on(mov.from).unwrap())
+                };
 
                 forcing_moves.push(ScoredMove { mov, score });
             }
@@ -74,10 +85,7 @@ impl QMoveGenerator {
     }
 
     pub fn next(&mut self) -> Option<Move> {
-        if let Some(index) = select_highest(&self.forcing_moves) {
-            let scored_move = self.forcing_moves.swap_remove(index);
-            return Some(scored_move.mov);
-        }
-        None
+        let index = select_highest(&self.forcing_moves)?;
+        Some(self.forcing_moves.swap_remove(index).mov)
     }
 }

--- a/search/src/searcher/quiescence.rs
+++ b/search/src/searcher/quiescence.rs
@@ -133,9 +133,11 @@ impl Searcher {
         }
 
         let mut best_eval = if in_check { -SCORE_INF } else { stand_pat };
+        let mut best_move = None;
         let mut captures_searched: ArrayVec<Move, 32> = ArrayVec::new();
 
-        let mut moves = QMoveGenerator::new(node, &self.capture_history);
+        let best_move_hint = tt_info.and_then(|t| t.best_move);
+        let mut moves = QMoveGenerator::new(node, &self.capture_history, best_move_hint);
 
         while let Some(mv) = moves.next() {
             // Per-move delta pruning (skip if capture can't possibly improve alpha)
@@ -189,6 +191,7 @@ impl Searcher {
 
             if value > best_eval {
                 best_eval = value;
+                best_move = Some(mv);
                 self.pv_table.update(ply, mv);
                 bounds.raise_alpha(best_eval);
             }
@@ -214,7 +217,7 @@ impl Searcher {
             Some(static_eval),
             original_bounds.alpha,
             original_bounds.beta,
-            None,
+            best_move,
         );
         best_eval
     }


### PR DESCRIPTION
## Summary

Makes sense to try the TT move first in QS as well.

So now it tries the TT move first (for captures and evasions) and stores the best QS move back into the TT.

Bench before:

```
Depth        : 14
Max seldepth : 37
Avg seldepth : 26.9
Total time   : 9637 ms
Total nodes  : 14060544
Avg NPS      : 1459016
Avg branching: 2.39
Bench hash   : 96F05167A84BEBEA
```

Bench after:

```
Depth        : 14
Max seldepth : 40
Avg seldepth : 27.0
Total time   : 9324 ms
Total nodes  : 13832192
Avg NPS      : 1483504
Avg branching: 2.38
Bench hash   : 4D286F70D4A2AEF6
```