### PR TITLE
perf: re-introduce nmp verification search

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -55,6 +55,7 @@ pub struct EngineConfig {
     pub nmp_base_reduction: u8,
     pub nmp_depth_divisor: u8,
     pub nmp_eval_margin: i16,
+    pub nmp_verify_min_depth: u8,
 
     pub lmp_max_depth: u8,
     pub lmp_base_moves: i32,
@@ -161,6 +162,7 @@ impl Default for EngineConfig {
             nmp_base_reduction: 2,
             nmp_depth_divisor: 3,
             nmp_eval_margin: 200,
+            nmp_verify_min_depth: 14,
 
             lmp_max_depth: 8,
             lmp_base_moves: 2,

--- a/search/src/searcher/mod.rs
+++ b/search/src/searcher/mod.rs
@@ -81,6 +81,10 @@ pub struct Searcher {
     /// Hard node-count limit for the search. When the cumulative node count
     /// (across all threads) reaches this, the search is stopped.
     node_limit: Option<u64>,
+
+    /// Disable NMP until this ply.
+    /// Only used during nmp verification (so set to 0 in normal search)
+    nmp_min_ply: u8,
 }
 
 impl Searcher {
@@ -123,6 +127,8 @@ impl Searcher {
 
             deadline: None,
             node_limit: None,
+
+            nmp_min_ply: 0,
         };
 
         instance.configure(config);

--- a/search/src/searcher/pruning.rs
+++ b/search/src/searcher/pruning.rs
@@ -153,6 +153,7 @@ impl Searcher {
             || in_check
             || !node.is_cut()
             || depth < self.config.nmp_min_depth
+            || ply < self.nmp_min_ply
             || node.is_zugzwang()
         {
             return None;
@@ -191,9 +192,8 @@ impl Searcher {
 
         // Do a reduced depth null search to check if our position is still good enough
         self.search_stack.push_node(&nm_child);
-        let reduced_child_depth = depth.saturating_sub(r + 1);
-        let null_value =
-            -self.search_node(&nm_child, reduced_child_depth, ply + 1, null_bounds, false);
+        let reduced_depth = depth.saturating_sub(r + 1);
+        let null_value = -self.search_node(&nm_child, reduced_depth, ply + 1, null_bounds, false);
         self.search_stack.pop();
 
         // Our position does not hold when giving opponent a free move, so let's not prune.
@@ -204,6 +204,23 @@ impl Searcher {
         // The null move is not realistic, so mates may not exist
         if null_value.abs() >= NEAR_MATE_VALUE {
             return None;
+        }
+
+        // Verify NMP decisions if the branch is big enough.
+        if self.nmp_min_ply == 0 && depth >= self.config.nmp_verify_min_depth {
+            self.nmp_min_ply = ply + 3 * reduced_depth / 4;
+            let verify_value = self.search_node(
+                node,
+                reduced_depth,
+                ply,
+                Bounds::null(bounds.beta.saturating_sub(1)),
+                false,
+            );
+            self.nmp_min_ply = 0;
+
+            if verify_value < bounds.beta {
+                return None;
+            }
         }
 
         self.shared.tt().store(

--- a/search/src/searcher/search.rs
+++ b/search/src/searcher/search.rs
@@ -206,6 +206,7 @@ impl Searcher {
     fn init_search(&mut self) {
         self.nodes = 0;
         self.max_ply_reached = 1;
+        self.nmp_min_ply = 0;
 
         self.search_stack.clear();
         self.search_stack.push(SearchNode::new(self.board.hash()));


### PR DESCRIPTION
## Summary

Tried this in #188 which I closed, but that version was borked and still do NMP pruned in the verification search. So it wasn't really verifying much.

This version follows the standard approach and disables NMP for a few plies during the re-search.


Bench before:

```
Depth        : 14
Max seldepth : 37
Avg seldepth : 26.9
Total time   : 9645 ms
Total nodes  : 14060544
Avg NPS      : 1457806
Avg branching: 2.39
Bench hash   : 96F05167A84BEBEA
```

Bench after:

```
Depth        : 14
Max seldepth : 40
Avg seldepth : 26.9
Total time   : 9730 ms
Total nodes  : 14155776
Avg NPS      : 1454858
Avg branching: 2.39
Bench hash   : 2343B4646E10C4E2
```